### PR TITLE
Fix some valgrind memcheck warnings. However there remains one...

### DIFF
--- a/projects/mtg/src/GameOptions.cpp
+++ b/projects/mtg/src/GameOptions.cpp
@@ -1188,10 +1188,11 @@ bool GameOptionKeyBindings::read(string input)
         iss.get(*(s.rdbuf()), ',');
         iss.get();
 
-        LocalKeySym local;
-        char sep;
-        u32 button;
+        LocalKeySym local = 0;
+        char sep = 0;
+        u32 button = 0;
         s >> local >> sep >> button;
+
         if (':' != sep)
             return false;
         assoc.push_back(make_pair(local, u32_to_button(button)));

--- a/projects/mtg/src/GameStateMenu.cpp
+++ b/projects/mtg/src/GameStateMenu.cpp
@@ -65,6 +65,7 @@ GameStateMenu::GameStateMenu(GameApp* parent) :
     scroller = NULL;
     langChoices = false;
     primitivesLoadCounter = -1;
+    bgTexture = NULL;
 }
 
 GameStateMenu::~GameStateMenu()


### PR DESCRIPTION
... within the threaded texture cache. Once it is resized, some textures
in GetQuad(...) (WCachedResource.cpp:102/103) have uninitialized widths/heights.
