### PR TITLE
Updated deckmenu.cpp to properly render deck description and summary

### DIFF
--- a/projects/mtg/src/DeckMenu.cpp
+++ b/projects/mtg/src/DeckMenu.cpp
@@ -293,6 +293,7 @@ void DeckMenu::Render()
                 
                 // fill in the description part of the screen
 				string text = wordWrap(_(currentMenuItem->getDescription()), descWidth, descriptionFont->mFontID );
+                descriptionFont->SetColor(ARGB(255,255,255,255));
                 descriptionFont->DrawString(text.c_str(), descX, descY);
                 
                 // fill in the statistical portion
@@ -301,6 +302,7 @@ void DeckMenu::Render()
                     ostringstream oss;
                     oss << _("Deck: ") << currentMenuItem->getDeckName() << endl;
                     oss << currentMenuItem->getDeckStatsSummary();
+                    descriptionFont->SetColor(ARGB(255,255,255,255));
                     descriptionFont->DrawString(oss.str(), statsX, statsY);
                 }
                 


### PR DESCRIPTION
Deck description and statistics were being drawn as black text, this made it invisible as it was rendered over a black background. I made it change the color to white before drawing, so its shown as its suposed to be.(Did the default text color change?)
