### PR TITLE
Changed Travis build file to use Android API 10 and Android build tools 18.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - wget http://dl.google.com/android/android-sdk_r22-linux.tgz -nv
   - tar --absolute-names -jxf android-ndk-r9-linux-x86_64.tar.bz2
   - tar -zxf android-sdk_r22-linux.tgz
-  - echo yes | $ANDROID update sdk --filter 1,2,3,8 --no-ui --force > log.txt
+  - echo yes | $ANDROID update sdk -a --filter 1,2,4,18 --no-ui --force > log.txt
 script: "./travis-script.sh"


### PR DESCRIPTION
This is a trivial change, but I wanted to explain it a bit.

I forked the repo to try a few things out on Travis on my own without spamming everyone with 'build failed' emails.  I tried at first to update the sdk with API 10 as such:

```
echo yes | $ANDROID update sdk --filter 1,2,3,14 --no-ui --force > log.txt
```

But as I suspected, the build failed as described in issue #567.  I fixed that by adding the -a switch (read: 'all') to be able to access the 18.1.1 android build tools.

P.S.
Sorry about the commit author as RyanInspiratica.  That is an old work account that I apparently forgot to change.
