### PR TITLE
Do not specify the system directory in JGE

### DIFF
--- a/JGE/src/JFileSystem.cpp
+++ b/JGE/src/JFileSystem.cpp
@@ -126,7 +126,7 @@ JFileSystem::JFileSystem(const string & _userPath, const string & _systemPath)
 	DebugTrace("User path " << userPath);
 #elif defined (QT_CONFIG)
 
-    QDir sysDir("projects/mtg/bin/Res");
+    QDir sysDir(RESDIR);
     QDir dir(QDir::homePath());
     dir.mkdir(USERDIR);
     dir.cd(USERDIR);

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -27,4 +27,5 @@ qmake projects/mtg/wagic-qt.pro CONFIG+=console CONFIG+=debug DEFINES+=CAPTURE_S
 make -j 8
 
 # and finish by running the testsuite
-./wagic
+cd projects/mtg
+./../../wagic


### PR DESCRIPTION
This removes the specification of the Res-directory from JFileSystem.cpp. Specifying a hardcoded path prevented packaging. To help travis find the Res-folder, we can either set RESDIR when we run qmake or run wagic from the project directory.
