### PR TITLE
Reset positions and filters when reopening the editor

### DIFF
--- a/projects/mtg/src/DeckView.cpp
+++ b/projects/mtg/src/DeckView.cpp
@@ -70,6 +70,8 @@ bool DeckView::ButtonPressed(Buttons button)
 void DeckView::SetDeck(DeckDataWrapper *toShow)
 {
     mCurrentDeck = toShow;
+    dirtyCardPos = true;
+    dirtyFilters = true;
     reloadIndexes();
 }
 

--- a/projects/mtg/src/GameStateDeckViewer.cpp
+++ b/projects/mtg/src/GameStateDeckViewer.cpp
@@ -167,6 +167,7 @@ void GameStateDeckViewer::Start()
     myCollection = NEW DeckDataWrapper(playerdata->collection);
     myCollection->Sort(WSrcCards::SORT_ALPHA);
     setupView(mCurrentView, myCollection);
+    toggleDeckButton->setText("View Deck");
 
     //Icons
     mIcons = manaIcons;


### PR DESCRIPTION
This will fix a bug that occurred when one opens a deck a second time and the view shows the wrong cards for a moment.
