### PR TITLE
Fix bug where the phase wheel got out of sync

### DIFF
--- a/projects/mtg/include/GuiPhaseBar.h
+++ b/projects/mtg/include/GuiPhaseBar.h
@@ -16,7 +16,6 @@ private:
     static const float step;
 
     int displayedPhaseId;
-    int newPhaseId;
     float angle;
     float zoomFactor;
     OutQuadEasing angleEasing;


### PR DESCRIPTION
The phase wheel counts phases within another unit and not mtg phases. It is important to map between those. I added this mapping to keep the code simple and correct hopefully this time. (Please test the wheel before merging because it is getting late (about 2 am) and I am not sure if I have found all possible regressions)  
