### PR TITLE
PT colors, Token and Cloner Indicators

### DIFF
--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -87132,7 +87132,7 @@ toughness=7
 [/card]
 [card]
 name=Silumgar Assassin
-abilities=strong
+abilities=evadebigger
 facedown={3}
 autofacedown={2}{B}:morph
 autofaceup=counter(1/1,1)

--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -6267,8 +6267,7 @@ abilities=flying,double strike
 facedown={3}
 autofacedown={4}{W}:morph
 autofaceup=counter(1/1,1)
-text=Flying
-Double strike (This creature deals both first-strike and regular combat damage.) -- Megamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)
+text=Flying -- Double strike (This creature deals both first-strike and regular combat damage.) -- Megamorph {4}{W} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.)
 mana={1}{W}{W}
 type=Creature
 subtype=Bird Warrior
@@ -18318,8 +18317,7 @@ name=Contradict
 target=*|stack
 auto=fizzle
 auto=draw:1 controller
-text=Counter target spell.
-Draw a card.
+text=Counter target spell. Draw a card.
 mana={3}{U}{U}
 type=Instant
 [/card]
@@ -23463,8 +23461,7 @@ facedown={3}
 autofacedown={1}{G}:morph
 autofaceup=counter(1/1,1)
 autofaceup=moveto(ownerhand) target(*|mygraveyard)
-text=Creatures with power less than Den Protector's power can't block it.
-Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.) -- When Den Protector is turned face up, return target card from your graveyard to your hand.
+text=Creatures with power less than Den Protector's power can't block it. Megamorph {1}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its megamorph cost and put a +1/+1 counter on it.) -- When Den Protector is turned face up, return target card from your graveyard to your hand.
 mana={1}{G}
 type=Creature
 subtype=Human Warrior
@@ -54467,8 +54464,7 @@ name=Learn from the Past
 target=player
 auto=moveTo(ownerlibrary) and!(shuffle)! all(*|targetedpersonsgraveyard)
 auto=draw:1 controller
-text=Target player shuffles his or her graveyard into his or her library.
-Draw a card.
+text=Target player shuffles his or her graveyard into his or her library. Draw a card.
 mana={3}{U}
 type=Instant
 [/card]
@@ -77324,8 +77320,7 @@ name=Rending Volley
 abilities=nofizzle
 target=creature[white;blue]|battlefield
 auto=damage:4
-text=Rending Volley can't be countered by spells or abilities.
-Rending Volley deals 4 damage to target white or blue creature.
+text=Rending Volley can't be countered by spells or abilities. Rending Volley deals 4 damage to target white or blue creature.
 mana={R}
 type=Instant
 [/card]

--- a/projects/mtg/include/MTGCardInstance.h
+++ b/projects/mtg/include/MTGCardInstance.h
@@ -239,6 +239,7 @@ public:
     int swapP;
     int swapT;
     bool isSwitchedPT;
+    bool isACopier;
 
     void eventattacked();
     void eventattackedAlone();

--- a/projects/mtg/include/MTGDefinitions.h
+++ b/projects/mtg/include/MTGDefinitions.h
@@ -225,7 +225,8 @@ class Constants
       LIBRARYDEATH = 107,
       SHUFFLELIBRARYDEATH = 108,
       OFFERING = 109,
-      NB_BASIC_ABILITIES = 110,
+      EVADEBIGGER = 110,
+      NB_BASIC_ABILITIES = 111,
 
 
     RARITY_S = 'S',   //Special Rarity

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -384,6 +384,7 @@ int AACopier::resolve()
     if (_target)
     {
         source->copy(_target);
+        source->isACopier = true;
         return 1;
     }
     return 0;

--- a/projects/mtg/src/CardGui.cpp
+++ b/projects/mtg/src/CardGui.cpp
@@ -314,7 +314,7 @@ void CardGui::Render()
 	{
         mFont->SetScale(DEFAULT_MAIN_FONT_SCALE);
         char buffer[200];
-        sprintf(buffer, "%c", buff);
+        sprintf(buffer, "%c", buff.c_str());
         mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,182,193));//Light Pink indicator
         mFont->SetScale(0.8f);
         mFont->DrawString(buffer, actX - 10 * actZ, actY - (16 * actZ));

--- a/projects/mtg/src/CardGui.cpp
+++ b/projects/mtg/src/CardGui.cpp
@@ -314,7 +314,7 @@ void CardGui::Render()
 	{
         mFont->SetScale(DEFAULT_MAIN_FONT_SCALE);
         char buffer[200];
-        sprintf(buffer, "%c", buff.c_str());
+        sprintf(buffer, "%s", buff.c_str());
         mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,182,193));//Light Pink indicator
         mFont->SetScale(0.8f);
         mFont->DrawString(buffer, actX - 10 * actZ, actY - (16 * actZ));

--- a/projects/mtg/src/CardGui.cpp
+++ b/projects/mtg/src/CardGui.cpp
@@ -287,29 +287,37 @@ void CardGui::Render()
             ARGB(((static_cast<unsigned char>(actA))/2),0,0,0));
         //damaged or buffed or powered down		
         if(card->wasDealtDamage && card->life <= 2)
-            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,0,0));//red
+            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,0,0));//red critical and damaged
         else if(!card->wasDealtDamage && card->pbonus < 0)
-            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),216,191,216));//thistle
-        else if(card->getRarity() == Constants::RARITY_T)
-            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),245,245,245));//smoke
+            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),216,191,216));//thistle powered down
+        else if(!card->wasDealtDamage && card->pbonus >= 3)
+            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,255,0));//yellow buff
         else if(card->hasType("legendary") && card->hasType("eldrazi"))
-            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),238,130,238));//violet
+            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),238,130,238));//violet legendary eldrazi
 		else
-            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,255,255));//white
+            mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,255,255));//white default
         mFont->SetScale(actZ);
         mFont->SetScale(actZ);
         mFont->DrawString(buffer, actX - 10 * actZ, actY + 8 * actZ);
         mFont->SetScale(1);
     }
 
-    if(card->getRarity() == Constants::RARITY_T)
+    string buff = "";
+    if(card->isToken && !card->isACopier)
+        buff = "T";
+    if(card->isToken && card->isACopier)
+        buff = "CT";
+    if(!card->isToken && card->isACopier)
+        buff = "C";    
+
+    if(!alternate && buff != "")
 	{
         mFont->SetScale(DEFAULT_MAIN_FONT_SCALE);
         char buffer[200];
-        sprintf(buffer, "T");
-        mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,222,173));//Navajo
+        sprintf(buffer, "%c", buff);
+        mFont->SetColor(ARGB(static_cast<unsigned char>(actA),255,182,193));//Light Pink indicator
         mFont->SetScale(0.8f);
-        mFont->DrawString(buffer, actX - 10 * actZ, actY - (18 * actZ));
+        mFont->DrawString(buffer, actX - 10 * actZ, actY - (16 * actZ));
         mFont->SetScale(1);
     }
 

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -56,6 +56,7 @@ MTGCardInstance::MTGCardInstance(MTGCard * card, MTGPlayerCards * arg_belongs_to
     isSettingBase = 0;
     isCDA = false;
     isSwitchedPT = false;
+    isACopier = false;
 }
 
   MTGCardInstance * MTGCardInstance::createSnapShot()
@@ -749,6 +750,8 @@ int MTGCardInstance::canBlock(MTGCardInstance * opponent)
     if (opponent->basicAbilities[(int)Constants::UNBLOCKABLE])
         return 0;
     if (opponent->basicAbilities[(int)Constants::ONEBLOCKER] && opponent->blocked)
+        return 0;
+    if(opponent->basicAbilities[(int)Constants::EVADEBIGGER] && power > opponent->power)
         return 0;
     if(opponent->basicAbilities[(int)Constants::STRONG] && power < opponent->power)
         return 0;

--- a/projects/mtg/src/MTGDefinitions.cpp
+++ b/projects/mtg/src/MTGDefinitions.cpp
@@ -138,7 +138,8 @@ const char* Constants::MTGBasicAbilities[] = {
     "oppgraveexiler",
     "librarydeath",
     "shufflelibrarydeath",
-    "offering"
+    "offering",
+    "evadebigger"
 };
 
 map<string,int> Constants::MTGBasicAbilitiesMap;


### PR DESCRIPTION
When a creature is damaged and has critical life, PT turns to
red(critical life is 2 and below), if a card has a powered down status
like from -1/-1 counter, the PT turns to thistle, if powered up 3 or more ,
the PT turns into yellow, default is white. legendary eldrazi pt is
violet. Token Indicator is T, and C for cards with copy abilities(so we
can differentiate them from originals), TC for both token and copycat
cards.