### PR TITLE
Fix Recover Cards, Cloner, Copier, and Preliminary support for Madness

### DIFF
--- a/projects/mtg/bin/Res/sets/primitives/borderline.txt
+++ b/projects/mtg/bin/Res/sets/primitives/borderline.txt
@@ -1,5 +1,16 @@
 grade=borderline
 [card]
+name=Arrogant Wurm
+abilities=trample,madness
+autoexile=restriction{discarded} pay({2}{G}) name(pay 2G to cast) activate name(pay 2G to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+text=Trample -- Madness {2}{G} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={3}{G}{G}
+type=Creature
+subtype=Wurm
+power=4
+toughness=4
+[/card]
+[card]
 name=Autumn Willow
 abilities=opponentshroud,shroud
 auto={G}:-shroud
@@ -24,6 +35,40 @@ power=2
 toughness=2
 [/card]
 [card]
+name=Basking Rootwalla
+abilities=madness
+autoexile=restriction{discarded} pay({0}) name(pay 0 to cast) activate name(pay 0 to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto={1}{G}:2/2 limit:1
+text={1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn. -- Madness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={G}
+type=Creature
+subtype=Lizard
+power=1
+toughness=1
+[/card]
+[card]
+name=Big Game Hunter
+abilities=madness
+autoexile=restriction{discarded} pay({B}) name(pay B to cast) activate name(pay B to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto=bury target(creature[power>=4])
+text=When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={1}{B}{B}
+type=Creature
+subtype=Human Rebel Assassin
+power=1
+toughness=1
+[/card]
+[card]
+name=Call to the Netherworld
+abilities=madness
+autoexile=restriction{discarded} pay({0}) name(pay 0 to cast) activate name(pay 0 to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature[black]|myGraveyard
+auto=moveTo(myHand)
+text=Return target black creature card from your graveyard to your hand. -- Madness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={B}
+type=Sorcery
+[/card]
+[card]
 name=Cinder Seer
 auto={2}{r}{t}:target(creature,Player) damage:type:*[red]:myhand
 text={2}{R}, {T}: Reveal any number of red cards in your hand. Cinder Seer deals X damage to target creature or player, where X is the number of cards revealed this way.
@@ -44,6 +89,16 @@ mana={1}{B}{G}
 type=Instant
 [/card]
 [card]
+name=Dark Withering
+abilities=madness
+autoexile=restriction{discarded} pay({B}) name(pay B to cast) activate name(pay B to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature[-black]
+auto=destroy
+text=Destroy target nonblack creature. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={4}{B}{B}
+type=Instant
+[/card]
+[card]
 name=Feral Hydra
 type=Creature
 subtype=Hydra Beast
@@ -54,6 +109,26 @@ text=Feral Hydra enters the battlefield with X +1/+1 counters on it. -- {3}: Put
 auto=counter(1/1,X)
 auto={3}:counter(1/1)
 #Not all player can use ability
+[/card]
+[card]
+name=Fiery Temper
+abilities=madness
+autoexile=restriction{discarded} pay({R}) name(pay R to cast) activate name(pay R to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature,player
+auto=damage:3
+text=Fiery Temper deals 3 damage to target creature or player. -- Madness {R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={1}{R}{R}
+type=Instant
+[/card]
+[card]
+name=Frantic Purification
+abilities=madness
+autoexile=restriction{discarded} pay({W}) name(pay W to cast) activate name(pay W to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=enchantment
+auto=destroy
+text=Destroy target enchantment. -- Madness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={2}{W}
+type=Instant
 [/card]
 [card]
 name=Ghastly Remains
@@ -77,12 +152,35 @@ power=4
 toughness=4
 [/card]
 [card]
+name=Gorgon Recluse
+abilities=madness
+autoexile=restriction{discarded} pay({B}{B}) name(pay BB to cast) activate name(pay BB to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto=@combat(blocked,blocking) source(this) from(creature):all(trigger[from]) phaseaction[combatends once] destroy
+text=Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat. -- Madness {B}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={3}{B}{B}
+type=Creature
+subtype=Gorgon
+power=2
+toughness=4
+[/card]
+[card]
 name=Govern the Guildless
 target=creature[-multicolor]
 auto=moveto(mybattlefield)
 autohand={1}{U}:name(change color/s) ability$!name(choose color/s) choice name(white) target(creature) becomes(,white) ueot _ choice name(blue) target(creature) becomes(,blue) ueot _ choice name(black) target(creature) becomes(,black) ueot _ choice name(red) target(creature) becomes(,red) ueot _ choice name(green) target(creature) becomes(,green) ueot _ choice name(white & blue) target(creature) becomes(,white,blue) ueot _ choice name(blue & black) target(creature) becomes(,black,blue) ueot _ choice name(black & red) target(creature) becomes(,black,red) ueot _ choice name(red & green) target(creature) becomes(,red,green) ueot _ choice name(green & white) target(creature) becomes(,white,green) ueot _ choice name(white & black) target(creature) becomes(,white,black) ueot _ choice name(blue & red) target(creature) becomes(,red,blue) ueot _ choice name(black & green) target(creature) becomes(,black,green) ueot _ choice name(red & white) target(creature) becomes(,white,red) ueot _ choice name(green & blue) target(creature) becomes(,green,blue) ueot _ choice name(green & white & blue) target(creature) becomes(,green,white,blue) ueot _ choice name(white & blue & black) target(creature) becomes(,black,white,blue) ueot _ choice name(blue & black & red) target(creature) becomes(,black,red,blue) ueot _ choice name(black & red & green) target(creature) becomes(,green,black,red) ueot _ choice name(red & green & white) target(creature) becomes(,green,white,red) ueot _ choice name(white & black & green) target(creature) becomes(,green,white,black) ueot _ choice name(blue & red & white) target(creature) becomes(,red,white,blue) ueot _ choice name(black & green & blue) target(creature) becomes(,green,black,blue) ueot _ choice name(red & white & black) target(creature) becomes(,black,white,red) ueot _ choice name(green & blue & red) target(creature) becomes(,green,red,blue) ueot _ choice name(green & red & blue & black) target(creature) becomes(,green,red,blue,black) ueot _ choice name(green & red & blue & white) target(creature) becomes(,green,red,blue,white) ueot _ choice name(white & blue & black & red) target(creature) becomes(,white,red,blue,black) ueot _ choice name(white & blue & black & green) target(creature) becomes(,white,green,blue,black) ueot _ choice name(all colors) target(creature) becomes(,white,red,blue,black,green) ueot!$ controller limit:1 myUpkeepOnly
 text=Gain control of target monocolored creature. -- Forecast - {1}{U}, Reveal Govern the Guildless from your hand: Target creature becomes the color or colors of your choice until end of turn. (Activate this ability only during your upkeep and only once each turn.)
 mana={5}{U}
+type=Sorcery
+[/card]
+[card]
+name=Ichor Slick
+abilities=madness
+autoexile=restriction{discarded} pay({3}{B}) name(pay 3B to cast) activate name(pay 3B to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature
+auto=-3/-3
+autohand=__CYCLING__({2})
+text=Target creature gets -3/-3 until end of turn. -- Cycling {2} ({2}, Discard this card: Draw a card.) -- Madness {3}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={2}{B}
 type=Sorcery
 [/card]
 [card]
@@ -149,6 +247,15 @@ power=1
 toughness=1
 [/card]
 [card]
+name=Obsessive Search
+abilities=madness
+autoexile=restriction{discarded} pay({U}) name(pay U to cast) activate name(pay U to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto=draw:1 controller
+text=Draw a card. -- Madness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={U}
+type=Instant
+[/card]
+[card]
 name=Ogre Marauder
 text=Whenever Ogre Marauder attacks, it gains "Ogre Marauder can't be blocked" until end of turn unless defending player sacrifices a creature.
 auto=@combat(attacking) source(this):ability$!name(choose one) if type(creature|mybattlefield)~morethan~0 then choice sacrifice notatarget(creature|mybattlefield) _ choice all(mystored) unblockable ueot!$ opponent
@@ -157,6 +264,15 @@ type=Creature
 subtype=Ogre Warrior
 power=3
 toughness=1
+[/card]
+[card]
+name=Psychotic Haze
+abilities=madness
+autoexile=restriction{discarded} pay({1}{B}) name(pay 1B to cast) activate name(pay 1B to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto=damage:1 all(creature,player)
+text=Psychotic Haze deals 1 damage to each creature and each player. -- Madness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={2}{B}{B}
+type=Instant
 [/card]
 [card]
 name=Rakdos Augermage
@@ -176,6 +292,17 @@ auto=moveto(exile) all(this)
 text=Discard X cards, then return a card from your graveyard to your hand for each card discarded this way. Exile Recall.
 mana={X}{X}{U}
 type=Sorcery
+[/card]
+[card]
+name=Reckless Wurm
+abilities=trample,madness
+autoexile=restriction{discarded} pay({2}{R}) name(pay 2R to cast) activate name(pay 2R to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+text=Trample -- Madness {2}{R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={3}{R}{R}
+type=Creature
+subtype=Wurm
+power=4
+toughness=4
 [/card]
 [card]
 name=Sacellum Godspeaker
@@ -234,6 +361,30 @@ auto=ability$!target(creature) 1/1 ueot!$ controller
 text=Target creature gets +1/+1 until end of turn. -- Target creature gets +1/+1 until end of turn. -- Target creature gets +1/+1 until end of turn.
 mana={G}{W}
 type=Instant
+[/card]
+[card]
+name=Strength of Isolation
+abilities=madness
+autoexile=restriction{discarded} pay({W}) name(pay W to cast) activate name(pay W to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature
+auto=1/2
+auto=protection from black
+text=Enchant creature -- Enchanted creature gets +1/+2 and has protection from black. -- Madness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={1}{W}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Strength of Lunacy
+abilities=madness
+autoexile=restriction{discarded} pay({B}) name(pay B to cast) activate name(pay B to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+target=creature
+auto=2/1
+auto=protection from white
+text=Enchant creature -- Enchanted creature gets +2/+1 and has protection from white. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
+mana={1}{B}
+type=Enchantment
+subtype=Aura
 [/card]
 [card]
 name=Zombie Brute

--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -22294,6 +22294,7 @@ text=At the beginning of your upkeep, you lose 1 life. -- At the beginning of yo
 mana={2}{B}{B}{B}
 type=Enchantment
 [/card]
+#tappedformana stack...
 [card]
 name=Dawn's Reflection
 target=land
@@ -33438,6 +33439,7 @@ subtype=Beast
 power=2
 toughness=2
 [/card]
+#tappedformana stack...
 [card]
 name=Fertile Ground
 target=land
@@ -37927,13 +37929,16 @@ type=Artifact
 [card]
 name=Gemstone Mine
 auto=counter(0/0,3,Mining)
-auto={T}{C(0/0,-1,Mining)}:Add{W}
-auto={T}{C(0/0,-1,Mining)}:Add{U}
-auto={T}{C(0/0,-1,Mining)}:Add{B}
-auto={T}{C(0/0,-1,Mining)}:Add{R}
-auto={T}{C(0/0,-1,Mining)}:Add{G}
-auto=@tapped(this):bury all(gemstone mine[-counter{0/0.1.Mining}])
-auto=this(counter{0/0.1.Mining}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Mining}>1) {T}{C(0/0,-1,Mining)}:Add{G}
+auto=this(counter{0/0,1,Mining}>1) {T}{C(0/0,-1,Mining)}:Add{R}
+auto=this(counter{0/0,1,Mining}>1) {T}{C(0/0,-1,Mining)}:Add{U}
+auto=this(counter{0/0,1,Mining}>1) {T}{C(0/0,-1,Mining)}:Add{B}
+auto=this(counter{0/0,1,Mining}>1) {T}{C(0/0,-1,Mining)}:Add{W}
+auto=this(counter{0/0,1,Mining}=1) {T}{C(0/0,-1,Mining)}:Add{G} && sacrifice
+auto=this(counter{0/0,1,Mining}=1) {T}{C(0/0,-1,Mining)}:Add{R} && sacrifice
+auto=this(counter{0/0,1,Mining}=1) {T}{C(0/0,-1,Mining)}:Add{U} && sacrifice
+auto=this(counter{0/0,1,Mining}=1) {T}{C(0/0,-1,Mining)}:Add{B} && sacrifice
+auto=this(counter{0/0,1,Mining}=1) {T}{C(0/0,-1,Mining)}:Add{W} && sacrifice
 text=Gemstone Mine enters the battlefield with three mining counters on it. -- {T}, Remove a mining counter from Gemstone Mine: Add one mana of any color to your mana pool. If there are no mining counters on Gemstone Mine, sacrifice it.
 type=Land
 [/card]
@@ -45571,9 +45576,8 @@ toughness=2
 name=Hickory Woodlot
 auto=tap
 auto=counter(0/0,2,Depletion)
-auto={T}{C(0/0,-1,Depletion)}:Add{G}{G}
-auto=@tapped(this):bury all(hickory woodlot[-counter{0/0.1.Depletion}])
-auto=this(counter{0/0.1.Depletion}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Depletion}>1) {T}{C(0/0,-1,Depletion)}:Add{G}{G}
+auto=this(counter{0/0,1,Depletion}=1) {T}{C(0/0,-1,Depletion)}:Add{G}{G} && sacrifice
 text=Hickory Woodlot enters the battlefield tapped with two depletion counters on it. -- {T}, Remove a depletion counter from Hickory Woodlot: Add {G}{G} to your mana pool. If there are no depletion counters on Hickory Woodlot, sacrifice it.
 type=Land
 [/card]
@@ -59969,6 +59973,7 @@ subtype=Insect
 power=2
 toughness=3
 [/card]
+#tappedformana stack...
 [card]
 name=Market Festival
 target=land
@@ -71418,9 +71423,8 @@ toughness=2
 name=Peat Bog
 auto=tap
 auto=counter(0/0,2,Depletion)
-auto={T}{C(0/0,-1,Depletion)}:Add{B}{B}
-auto=@tapped(this):bury all(peat bog[-counter{0/0.1.Depletion}]|myBattlefield)
-auto=this(counter{0/0.1.Depletion}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Depletion}>1) {T}{C(0/0,-1,Depletion)}:Add{B}{B}
+auto=this(counter{0/0,1,Depletion}=1) {T}{C(0/0,-1,Depletion)}:Add{B}{B} && sacrifice
 text=Peat Bog enters the battlefield tapped with two depletion counters on it. -- {T}, Remove a depletion counter from Peat Bog: Add {B}{B} to your mana pool. If there are no depletion counters on Peat Bog, sacrifice it.
 type=Land
 [/card]
@@ -78998,9 +79002,8 @@ type=Sorcery
 name=Remote Farm
 auto=tap
 auto=counter(0/0,2,Depletion)
-auto={T}{C(0/0,-1,Depletion)}:Add{W}{W}
-auto=@tapped(this):bury all(remote farm[-counter{0/0.1.Depletion}]|myBattlefield)
-auto=this(counter{0/0.1.Depletion}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Depletion}>1) {T}{C(0/0,-1,Depletion)}:Add{W}{W}
+auto=this(counter{0/0,1,Depletion}=1) {T}{C(0/0,-1,Depletion)}:Add{W}{W} && sacrifice
 text=Remote Farm enters the battlefield tapped with two depletion counters on it. -- {T}, Remove a depletion counter from Remote Farm: Add {W}{W} to your mana pool. If there are no depletion counters on Remote Farm, sacrifice it.
 type=Land
 [/card]
@@ -83233,9 +83236,8 @@ type=Artifact
 name=Sandstone Needle
 auto=tap
 auto=counter(0/0,2,Depletion)
-auto={T}{C(0/0,-1,Depletion)}:Add{R}{R}
-auto=@tapped(this):bury all(sandstone needle[-counter{0/0.1.Depletion}]|myBattlefield)
-auto=this(counter{0/0.1.Depletion}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Depletion}>1) {T}{C(0/0,-1,Depletion)}:Add{R}{R}
+auto=this(counter{0/0,1,Depletion}=1) {T}{C(0/0,-1,Depletion)}:Add{R}{R} && sacrifice
 text=Sandstone Needle enters the battlefield tapped with two depletion counters on it. -- {T}, Remove a depletion counter from Sandstone Needle: Add {R}{R} to your mana pool. If there are no depletion counters on Sandstone Needle, sacrifice it.
 type=Land
 [/card]
@@ -83471,9 +83473,8 @@ toughness=2
 name=Saprazzan Skerry
 auto=tap
 auto=counter(0/0,2,Depletion)
-auto={T}{C(0/0,-1,Depletion)}:Add{U}{U}
-auto=@tapped(this):bury all(saprazzan skerry[-counter{0/0.1.Depletion}]|myBattlefield)
-auto=this(counter{0/0.1.Depletion}<1) {0}:sacrifice all(this)
+auto=this(counter{0/0,1,Depletion}>1) {T}{C(0/0,-1,Depletion)}:Add{U}{U}
+auto=this(counter{0/0,1,Depletion}=1) {T}{C(0/0,-1,Depletion)}:Add{U}{U} && sacrifice
 text=Saprazzan Skerry enters the battlefield tapped with two depletion counters on it. -- {T}, Remove a depletion counter from Saprazzan Skerry: Add {U}{U} to your mana pool. If there are no depletion counters on Saprazzan Skerry, sacrifice it.
 type=Land
 [/card]
@@ -103853,6 +103854,7 @@ subtype=Spellshaper
 power=1
 toughness=1
 [/card]
+#tappedformana stack...
 [card]
 name=Trace of Abundance
 target=land
@@ -108211,6 +108213,7 @@ subtype=Elemental
 power=7
 toughness=7
 [/card]
+#tappedformana stack...
 [card]
 name=Verdant Haven
 target=land

--- a/projects/mtg/bin/Res/sets/primitives/unsupported.txt
+++ b/projects/mtg/bin/Res/sets/primitives/unsupported.txt
@@ -470,15 +470,6 @@ type=Enchantment
 subtype=Aura
 [/card]
 [card]
-name=Arrogant Wurm
-text=Trample -- Madness {2}{G} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={3}{G}{G}
-type=Creature
-subtype=Wurm
-power=4
-toughness=4
-[/card]
-[card]
 name=Arrow Volley Trap
 text=If four or more creatures are attacking, you may pay {1}{W} rather than pay Arrow Volley Trap's mana cost. -- Arrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.
 mana={3}{W}{W}
@@ -993,15 +984,6 @@ toughness=4
 text=Flying -- Players can't cast spells during combat. {R}: Target creature attacks this turn if able.
 [/card]
 [card]
-name=Basking Rootwalla
-text={1}{G}: Basking Rootwalla gets +2/+2 until end of turn. Activate this ability only once each turn. -- Madness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={G}
-type=Creature
-subtype=Lizard
-power=1
-toughness=1
-[/card]
-[card]
 name=Baton of Morale
 text={2}: Target creature gains banding until end of turn. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
 mana={2}
@@ -1160,15 +1142,6 @@ name=Betrayal of Flesh
 text=Choose one - Destroy target creature; or return target creature card from your graveyard to the battlefield. -- Entwine - Sacrifice three lands. (Choose both if you pay the entwine cost.)
 mana={5}{B}
 type=Instant
-[/card]
-[card]
-name=Big Game Hunter
-text=When Big Game Hunter enters the battlefield, destroy target creature with power 4 or greater. It can't be regenerated. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={1}{B}{B}
-type=Creature
-subtype=Human Rebel Assassin
-power=1
-toughness=1
 [/card]
 [card]
 name=Bind
@@ -1873,12 +1846,6 @@ name=Call to Arms
 text=As Call to Arms enters the battlefield, choose a color and an opponent. -- White creatures get +1/+1 as long as the chosen color is the most common color among nontoken permanents the chosen player controls but isn't tied for most common. -- When the chosen color isn't the most common color among nontoken permanents the chosen player controls or is tied for most common, sacrifice Call to Arms.
 mana={1}{W}
 type=Enchantment
-[/card]
-[card]
-name=Call to the Netherworld
-text=Return target black creature card from your graveyard to your hand. -- Madness {0} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={B}
-type=Sorcery
 [/card]
 [card]
 name=Callous Deceiver
@@ -3420,12 +3387,6 @@ name=Dark Tutelage
 text=At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its converted mana cost.
 mana={2}{B}
 type=Enchantment
-[/card]
-[card]
-name=Dark Withering
-text=Destroy target nonblack creature. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={4}{B}{B}
-type=Instant
 [/card]
 [card]
 name=Darkpact
@@ -5116,12 +5077,6 @@ mana={R}{G}{W}
 type=Sorcery
 [/card]
 [card]
-name=Fiery Temper
-text=Fiery Temper deals 3 damage to target creature or player. -- Madness {R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={1}{R}{R}
-type=Instant
-[/card]
-[card]
 name=Fight or Flight
 text=At the beginning of each opponent's combat phase, separate all creatures that player controls into two piles. Only creatures in the pile of his or her choice can attack this turn.
 mana={3}{W}
@@ -5555,12 +5510,6 @@ toughness=3
 text=At the beginning of your upkeep, you may ask target player a yes-or-no question. If you do, that player answers the question truthfully and abides by that answer if able until end of turn.
 [/card]
 [card]
-name=Frantic Purification
-text=Destroy target enchantment. -- Madness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={2}{W}
-type=Instant
-[/card]
-[card]
 name=Frazzled Editor
 mana={1}{R}
 type=Creature — Human Bureaucrat
@@ -5928,8 +5877,14 @@ subtype=Turtle
 power=2
 toughness=4
 [/card]
+#bug phasealter not turning off
 [card]
 name=Gibbering Descent
+abilities=madness
+autoexile=restriction{discarded} pay({2}{B}{B}) name(pay 2BB to cast) activate name(pay 2BB to cast) castcard(normal)?name(put in graveyard) moveto(ownergraveyard)
+auto=@each my upkeep:life:-1 controller && reject target(*|myhand)
+auto=@each opponentupkeep:life:-1 opponent && ability$!name(discard) target(*|myhand) reject!$ opponent
+auto=this(variable{phandcount} <1) phasealter(remove,upkeep,controller)
 text=At the beginning of each player's upkeep, that player loses 1 life and discards a card. -- Hellbent - Skip your upkeep step if you have no cards in hand. -- Madness {2}{B}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
 mana={4}{B}{B}
 type=Enchantment
@@ -6427,15 +6382,6 @@ type=Creature
 subtype=Jellyfish
 power=0
 toughness=3
-[/card]
-[card]
-name=Gorgon Recluse
-text=Whenever Gorgon Recluse blocks or becomes blocked by a nonblack creature, destroy that creature at end of combat. -- Madness {B}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={3}{B}{B}
-type=Creature
-subtype=Gorgon
-power=2
-toughness=4
 [/card]
 [card]
 name=Gorilla Berserkers
@@ -7439,12 +7385,6 @@ type=Creature
 subtype=Human Druid
 power=1
 toughness=1
-[/card]
-[card]
-name=Ichor Slick
-text=Target creature gets -3/-3 until end of turn. -- Cycling {2} ({2}, Discard this card: Draw a card.) -- Madness {3}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={2}{B}
-type=Sorcery
 [/card]
 [card]
 name=Icy Prison
@@ -11068,12 +11008,6 @@ type=Legendary Artifact
 subtype=Equipment
 [/card]
 [card]
-name=Obsessive Search
-text=Draw a card. -- Madness {U} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={U}
-type=Instant
-[/card]
-[card]
 name=Obstinate Baloth
 auto=life:4
 text=When Obstinate Baloth enters the battlefield, you gain 4 life. -- If a spell or ability an opponent controls causes you to discard Hardheaded Baloth, put it onto the battlefield instead of putting it into your graveyard.
@@ -12425,12 +12359,6 @@ mana={1}{B}{B}
 type=Sorcery
 [/card]
 [card]
-name=Psychotic Haze
-text=Psychotic Haze deals 1 damage to each creature and each player. -- Madness {1}{B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={2}{B}{B}
-type=Instant
-[/card]
-[card]
 name=Puca's Mischief
 text=At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.
 mana={3}{U}
@@ -12981,15 +12909,6 @@ name=Rebuff the Wicked
 text=Counter target spell that targets a permanent you control.
 mana={W}
 type=Instant
-[/card]
-[card]
-name=Reckless Wurm
-text=Trample -- Madness {2}{R} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={3}{R}{R}
-type=Creature
-subtype=Wurm
-power=4
-toughness=4
 [/card]
 [card]
 name=Reclamation
@@ -16052,20 +15971,6 @@ name=Street Spasm
 text=Street Spasm deals X damage to target creature without flying you don't control. -- Overload {X}{X}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
 mana={X}{R}
 type=Instant
-[/card]
-[card]
-name=Strength of Isolation
-text=Enchant creature -- Enchanted creature gets +1/+2 and has protection from black. -- Madness {W} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={1}{W}
-type=Enchantment
-subtype=Aura
-[/card]
-[card]
-name=Strength of Lunacy
-text=Enchant creature -- Enchanted creature gets +2/+1 and has protection from white. -- Madness {B} (If you discard this card, you may cast it for its madness cost instead of putting it into your graveyard.)
-mana={1}{B}
-type=Enchantment
-subtype=Aura
 [/card]
 [card]
 name=Strength of the Tajuru

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -2068,6 +2068,7 @@ public:
 
             assert(value < 2);
             _target->basicAbilities.set(ability, value > 0);
+            _target->modifiedbAbi += 1;
             return InstantAbility::addToGame();
         }
 
@@ -2080,7 +2081,10 @@ public:
     {
         MTGCardInstance * _target = (MTGCardInstance *) target;
         if (_target)
+        {
             _target->basicAbilities.set(ability, stateBeforeActivation);
+            _target->modifiedbAbi -= 1;
+        }
         return 1;
     }
 

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -556,6 +556,15 @@ private:
                 intValue = card->previous->previous->sunburst;
             }
         }
+        else if (s == "converge")
+        {
+            intValue = 0;
+            for (int i = Constants::MTG_COLOR_GREEN; i <= Constants::MTG_COLOR_WHITE; ++i)
+            {
+                if(card->getManaCost()->getManaUsedToCast()->hasColor(i))
+                    intValue +=1;
+            }
+        }
         else if (s == "targetedcurses")
         {
             if(card->playerTarget)

--- a/projects/mtg/include/CardPrimitive.h
+++ b/projects/mtg/include/CardPrimitive.h
@@ -58,6 +58,7 @@ public:
     uint8_t colors;
     typedef std::bitset<Constants::NB_BASIC_ABILITIES> BasicAbilitiesSet;
     BasicAbilitiesSet basicAbilities;
+    BasicAbilitiesSet origbasicAbilities;
 
     map<string,string> magicTexts;
     string magicText;

--- a/projects/mtg/include/MTGCardInstance.h
+++ b/projects/mtg/include/MTGCardInstance.h
@@ -241,6 +241,7 @@ public:
     bool isSwitchedPT;
     bool isACopier;
     bool bypassTC;
+    bool discarded;
 
     void eventattacked();
     void eventattackedAlone();

--- a/projects/mtg/include/MTGCardInstance.h
+++ b/projects/mtg/include/MTGCardInstance.h
@@ -242,6 +242,8 @@ public:
     bool isACopier;
     bool bypassTC;
     bool discarded;
+    int copiedID;
+    int modifiedbAbi;
 
     void eventattacked();
     void eventattackedAlone();

--- a/projects/mtg/include/MTGDefinitions.h
+++ b/projects/mtg/include/MTGDefinitions.h
@@ -230,7 +230,8 @@ class Constants
       NOLIFEGAIN = 112,
       NOLIFEGAINOPPONENT = 113,
       AURAWARD = 114,
-      NB_BASIC_ABILITIES = 115,
+      MADNESS = 115,
+      NB_BASIC_ABILITIES = 116,
 
 
     RARITY_S = 'S',   //Special Rarity

--- a/projects/mtg/include/MTGRules.h
+++ b/projects/mtg/include/MTGRules.h
@@ -76,7 +76,7 @@ public:
     MTGPutInPlayRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "cast card normally";
+        return "Cast Card Normally";
     }
     virtual MTGPutInPlayRule * clone() const;
 };
@@ -90,7 +90,7 @@ public:
     MTGKickerRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "pay kicker";
+        return "Pay Kicker";
     }
     virtual MTGKickerRule * clone() const;
 };
@@ -110,7 +110,7 @@ public:
     {
         if(alternativeName.size())
             return alternativeName.c_str();
-        return "pay alternative cost";
+        return "Pay Alternative Cost";
     }
     virtual MTGAlternativeCostRule * clone() const;
 };
@@ -124,7 +124,7 @@ public:
     MTGBuyBackRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "cast and buy back";
+        return "Cast and Buyback";
     }
     virtual MTGBuyBackRule * clone() const;
 };
@@ -139,7 +139,7 @@ public:
     MTGFlashBackRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "flash back";
+        return "Flashback";
     }
     virtual MTGFlashBackRule * clone() const;
 };
@@ -153,7 +153,7 @@ public:
     MTGRetraceRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "retrace";
+        return "Retrace";
     }
     virtual MTGRetraceRule * clone() const;
 };
@@ -168,7 +168,7 @@ public:
     MTGMorphCostRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "play morphed";
+        return "Play Morphed";
     }
     virtual MTGMorphCostRule * clone() const;
 };
@@ -182,7 +182,7 @@ public:
     MTGPlayFromGraveyardRule(GameObserver* observer, int _id);
     const string getMenuText()
     {
-        return "cast card from graveyard";
+        return "Cast Card From Graveyard";
     }
     virtual MTGPlayFromGraveyardRule * clone() const;
 };

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -1160,14 +1160,14 @@ int GenericPaidAbility::resolve()
         baseAbility->target = target;
         optionalCost =  ManaCost::parseManaCost(baseCost, NULL, source);
 
-        // hacky way to produce better MenuText
+        /*// hacky way to produce better MenuText
         AAFakeAbility* isFake = dynamic_cast< AAFakeAbility* >( baseAbility );
         size_t findPayN = isFake->named.find(" {value} mana");
         if (isFake && findPayN != string::npos) {
             stringstream parseN;
             parseN << optionalCost->getCost(Constants::MTG_COLOR_ARTIFACT);
             isFake->named.replace(findPayN + 1, 7, parseN.str());
-        }
+        }//commented out, it crashes cards with recover ability*/
 
         MTGAbility * set = baseAbility->clone();
         set->oneShot = true;
@@ -5724,7 +5724,7 @@ const string AACastCard::getMenuText()
         return nameThis.c_str();
     if(putinplay)
         return "Put Into Play";
-    return "Cast For Free";
+    return "Cast Card";
 }
 
 AACastCard * AACastCard::clone() const

--- a/projects/mtg/src/CardPrimitive.cpp
+++ b/projects/mtg/src/CardPrimitive.cpp
@@ -41,6 +41,7 @@ CardPrimitive::CardPrimitive(CardPrimitive * source)
     if(!source)
         return;
     basicAbilities = source->basicAbilities;
+    origbasicAbilities = source->basicAbilities;
 
     for (size_t i = 0; i < source->types.size(); ++i)
         types.push_back(source->types[i]);
@@ -76,6 +77,7 @@ CardPrimitive::~CardPrimitive()
 int CardPrimitive::init()
 {
     basicAbilities.reset();
+    origbasicAbilities.reset();
 
     types.clear();
 

--- a/projects/mtg/src/GameObserver.cpp
+++ b/projects/mtg/src/GameObserver.cpp
@@ -804,11 +804,6 @@ void GameObserver::gameStateBasedEffects()
                 c->damageToOpponent = false;
                 c->damageToCreature = false;
                 c->isAttacking = NULL;
-                if(c->modifiedbAbi > 0)
-                {
-                    c->modifiedbAbi = 0;
-                    c->basicAbilities = c->origbasicAbilities;
-                }
             }
             for (int t = 0; t < nbcards; t++)
             {
@@ -828,6 +823,11 @@ void GameObserver::gameStateBasedEffects()
                         p->game->putInExile(c);
 
                     }
+                }
+                if(c->modifiedbAbi > 0)
+                {
+                    c->modifiedbAbi = 0;
+                    c->basicAbilities = c->origbasicAbilities;
                 }
                 if(nbcards > z->nb_cards)
                 {

--- a/projects/mtg/src/GameObserver.cpp
+++ b/projects/mtg/src/GameObserver.cpp
@@ -804,6 +804,11 @@ void GameObserver::gameStateBasedEffects()
                 c->damageToOpponent = false;
                 c->damageToCreature = false;
                 c->isAttacking = NULL;
+                if(c->modifiedbAbi > 0)
+                {
+                    c->modifiedbAbi = 0;
+                    c->basicAbilities = c->origbasicAbilities;
+                }
             }
             for (int t = 0; t < nbcards; t++)
             {

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -411,6 +411,13 @@ int AbilityFactory::parseCastRestrictions(MTGCardInstance * card, Player * playe
             }
         }
 
+        check = restriction[i].find("discarded");
+        if(check != string::npos)
+        {
+            if(!card->discarded)
+                return 0;
+        }
+
         check = restriction[i].find("ownerscontrol");
         if(check != string::npos)
         {
@@ -3542,6 +3549,9 @@ int AbilityFactory::abilityEfficiency(MTGAbility * a, Player * p, int mode, Targ
     badAbilities[(int)Constants::WEAK] = true;
     badAbilities[(int)Constants::NOLIFEGAIN] = true;
     badAbilities[(int)Constants::NOLIFEGAINOPPONENT] = true;
+    badAbilities[(int)Constants::CANTLOSE] = false;
+    badAbilities[(int)Constants::CANTLIFELOSE] = false;
+    badAbilities[(int)Constants::CANTMILLLOSE] = false;
 
     if (AInstantBasicAbilityModifierUntilEOT * abi = dynamic_cast<AInstantBasicAbilityModifierUntilEOT *>(a))
     {

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -59,6 +59,8 @@ MTGCardInstance::MTGCardInstance(MTGCard * card, MTGPlayerCards * arg_belongs_to
     isACopier = false;
     bypassTC = false;
     discarded = false;
+    copiedID = getId();
+    modifiedbAbi = 0;
 }
 
   MTGCardInstance * MTGCardInstance::createSnapShot()
@@ -76,6 +78,8 @@ void MTGCardInstance::copy(MTGCardInstance * card)
     CardPrimitive * data = source->data;
 
     basicAbilities = card->basicAbilities;
+    origbasicAbilities = card->origbasicAbilities;
+    modifiedbAbi = card->modifiedbAbi;
     for (size_t i = 0; i < data->types.size(); i++)
     {
         types.push_back(data->types[i]);

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -58,6 +58,7 @@ MTGCardInstance::MTGCardInstance(MTGCard * card, MTGPlayerCards * arg_belongs_to
     isSwitchedPT = false;
     isACopier = false;
     bypassTC = false;
+    discarded = false;
 }
 
   MTGCardInstance * MTGCardInstance::createSnapShot()

--- a/projects/mtg/src/MTGDefinitions.cpp
+++ b/projects/mtg/src/MTGDefinitions.cpp
@@ -143,7 +143,8 @@ const char* Constants::MTGBasicAbilities[] = {
     "spellmastery",
     "nolifegain",
     "nolifegainopponent",
-    "auraward"
+    "auraward",
+    "madness"
 };
 
 map<string,int> Constants::MTGBasicAbilitiesMap;

--- a/projects/mtg/src/MTGGameZones.cpp
+++ b/projects/mtg/src/MTGGameZones.cpp
@@ -325,6 +325,15 @@ MTGCardInstance * MTGPlayerCards::putInZone(MTGCardInstance * card, MTGGameZone 
 	bool ripToken = false;
 	if (g->players[0]->game->battlefield->hasName("Rest in Peace")||g->players[1]->game->battlefield->hasName("Rest in Peace"))
         ripToken = true;
+    //Madness or Put in Play...
+    for(int i = 0; i < 2; ++i)
+	{
+        if (card->discarded && (to == g->players[i]->game->graveyard) && (from == g->players[i]->game->hand))
+        {
+            if(card->basicAbilities[(int)Constants::MADNESS])
+                to = g->players[i]->game->exile;
+        }
+    }
     //Darksteel Colossus, Legacy Weapon ... top priority since we replace destination directly automatically...
     for(int i = 0; i < 2; ++i)
 	{
@@ -360,6 +369,13 @@ MTGCardInstance * MTGPlayerCards::putInZone(MTGCardInstance * card, MTGGameZone 
     if (card->miracle)
     {
         copy->miracle = true;
+    }
+    if (card->discarded)
+    {//set discarded for madness...
+        if(from == g->players[0]->game->hand || from == g->players[1]->game->hand)
+            copy->discarded = true;
+		else//turn off discarded if its previous zone is not in hand...
+            copy->discarded = false;
     }
     if (options[Options::SFXVOLUME].number > 0)
     {

--- a/projects/mtg/src/WEvent.cpp
+++ b/projects/mtg/src/WEvent.cpp
@@ -106,6 +106,7 @@ WEventCardSacrifice::WEventCardSacrifice(MTGCardInstance * card, MTGCardInstance
 WEventCardDiscard::WEventCardDiscard(MTGCardInstance * card) :
     WEventCardUpdate(card)
 {
+    card->discarded = true;
 }
 
 WEventCardCycle::WEventCardCycle(MTGCardInstance * card) :


### PR DESCRIPTION
Madness cards are in borderline, the exiling of cards is automated.
Cloner and Copier ability should copy their respective targets if you are cloning or copying a cloner or copier.