### PR TITLE
revised producemana, added producecolor

### DIFF
--- a/projects/mtg/Android/AndroidManifest.xml
+++ b/projects/mtg/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="0192" android:versionName="@string/app_version" package="net.wagic.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="0201" android:versionName="@string/app_version" package="net.wagic.app">
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/projects/mtg/Android/res/values/strings.xml
+++ b/projects/mtg/Android/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Wagic</string>
-    <string name="app_version">0.19.2</string>
-    <string name="info_text">Wagic v0.19.2\\nAll Rights Reserved.</string>
+    <string name="app_version">0.20.1</string>
+    <string name="info_text">Wagic v0.20.1\\nAll Rights Reserved.</string>
 </resources>

--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -45724,7 +45724,7 @@ toughness=4
 [/card]
 [card]
 name=High Tide
-auto=all(island) transforms((,newability[produceextra:{U}])) ueot
+auto=emblem transforms((,newability[lord(island) produceextra:{U}])) ueot
 text=Until end of turn, whenever a player taps an Island for mana, that player adds {U} to his or her mana pool (in addition to the mana the land produces).
 mana={U}
 type=Instant

--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -22294,7 +22294,7 @@ text=At the beginning of your upkeep, you lose 1 life. -- At the beginning of yo
 mana={2}{B}{B}{B}
 type=Enchantment
 [/card]
-#tappedformana stack...
+#tappedformana stack...produceextra:selectmana don't support combination of mana at the moment since it a mayability not a menuability
 [card]
 name=Dawn's Reflection
 target=land
@@ -29463,7 +29463,7 @@ type=Instant
 [card]
 name=Elvish Guidance
 target=land
-auto=@tappedformana(mytgt):foreach(elf|myBattlefield) Add{G} targetcontroller
+auto=transforms((,newability[foreach(elf|battlefield) produceextra:{G}]))
 text=Enchant land -- Whenever enchanted land is tapped for mana, its controller adds {G} to his or her mana pool for each Elf on the battlefield (in addition to the mana the land produces).
 mana={2}{G}
 type=Enchantment
@@ -33016,7 +33016,7 @@ auto=@targeted(this) from(*[instant;sorcery;enchantment]|myhand,mygraveyard):cou
 text=Heroic - Whenever you cast a spell that targets Favored Hoplite, put a +1/+1 counter on Favored Hoplite and prevent all damage that would be dealt to it this turn.
 mana={W}
 type=Creature
-subtype=Human Warrior
+subtype=Human Soldier
 power=1
 toughness=2
 [/card]
@@ -33439,11 +33439,11 @@ subtype=Beast
 power=2
 toughness=2
 [/card]
-#tappedformana stack...
+#produceextra:selectmana when used acts as an observer so the ability must be on the source since its a mayability of mana not a menuability
 [card]
 name=Fertile Ground
 target=land
-auto=teach(land) transforms((,newability[@tappedformana(this):chooseacolor add{chosencolor} chooseend]))
+auto=all(this) transforms((,newability[produceextra:selectmana])) forever
 text=Enchant land -- Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).
 mana={1}{G}
 type=Enchantment
@@ -37700,13 +37700,14 @@ text=Red creatures get +1/+1. -- Whenever a Mountain is tapped for mana, its con
 mana={4}
 type=Artifact
 [/card]
+#producecolor looks for the color... maybe needs restriction...
 [card]
 name=Gauntlet of Power
-auto=choice name(choose white) all(this) transforms((,newability[lord(creature[white]|battlefield) 1/1],newability[@tappedformana(plains[basic]|mybattlefield):add{W}],newability[@tappedformana(plains[basic]|opponentbattlefield):add{W} opponent])) forever
-auto=choice name(choose blue) all(this) transforms((,newability[lord(creature[blue]|battlefield) 1/1],newability[@tappedformana(island[basic]|mybattlefield):add{U}],newability[@tappedformana(island[basic]|opponentbattlefield):add{U} opponent])) forever
-auto=choice name(choose black) all(this) transforms((,newability[lord(creature[black]|battlefield) 1/1],newability[@tappedformana(swamp[basic]|mybattlefield):add{B}],newability[@tappedformana(swamp[basic]|opponentbattlefield):add{B} opponent])) forever
-auto=choice name(choose red) all(this) transforms((,newability[lord(creature[red]|battlefield) 1/1],newability[@tappedformana(mountain[basic]|mybattlefield):add{R}],newability[@tappedformana(mountain[basic]|opponentbattlefield):add{R} opponent])) forever
-auto=choice name(choose green) all(this) transforms((,newability[lord(creature[green]|battlefield) 1/1],newability[@tappedformana(forest[basic]|mybattlefield):add{G}],newability[@tappedformana(forest[basic]|opponentbattlefield):add{G} opponent])) forever
+auto=choice name(green) all(this) transforms((,newability[lord(creature[green]|battlefield) 1/1],newability[lord(forest[basic]|battlefield) producecolor:green])) forever
+auto=choice name(blue) all(this) transforms((,newability[lord(creature[blue]|battlefield) 1/1],newability[lord(island[basic]|battlefield) producecolor:blue])) forever
+auto=choice name(red) all(this) transforms((,newability[lord(creature[red]|battlefield) 1/1],newability[lord(mountain[basic]|battlefield) producecolor:red])) forever
+auto=choice name(black) all(this) transforms((,newability[lord(creature[black]|battlefield) 1/1],newability[lord(swamp[basic]|battlefield) producecolor:black])) forever
+auto=choice name(white) all(this) transforms((,newability[lord(creature[white]|battlefield) 1/1],newability[lord(plains[basic]|battlefield) producecolor:white])) forever
 text=As Gauntlet of Power enters the battlefield, choose a color. -- Creatures of the chosen color get +1/+1. -- Whenever a basic land is tapped for mana of the chosen color, its controller adds one mana of that color to his or her mana pool (in addition to the mana the land produces).
 mana={5}
 type=Artifact
@@ -59972,7 +59973,7 @@ subtype=Insect
 power=2
 toughness=3
 [/card]
-#tappedformana stack...
+#tappedformana stack...produceextra:selectmana don't support combination of mana at the moment since it a mayability not a menuability
 [card]
 name=Market Festival
 target=land
@@ -61210,7 +61211,7 @@ auto=@movedTo(other creature[power<=2]|myBattlefield):pay({1}) draw:1
 text=Whenever another creature with power 2 or less enters the battlefield under your control, you may pay {1}. If you do, draw a card.
 mana={2}{W}
 type=Creature
-subtype=Human Solider
+subtype=Human Soldier
 power=2
 toughness=2
 [/card]
@@ -103864,12 +103865,12 @@ subtype=Spellshaper
 power=1
 toughness=1
 [/card]
-#tappedformana stack...
+#produceextra:selectmana when used acts as an observer so the ability must be on the source since its a mayability of mana not a menuability
 [card]
 name=Trace of Abundance
 target=land
 auto=shroud
-auto=teach(land) transforms((,newability[@tappedformana(this):chooseacolor add{chosencolor} chooseend]))
+auto=all(this) transforms((,newability[produceextra:selectmana])) forever
 text=Enchant land -- Enchanted land has shroud. (It can't be the target of spells or abilities.) -- Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).
 mana={RW}{G}
 type=Enchantment
@@ -107039,7 +107040,11 @@ toughness=2
 [card]
 name=Utopia Sprawl
 target=forest
-auto=chooseacolor transforms((,newability[@tappedformana(mytgt):add{chosencolor}])) forever chooseend
+auto=choice name(green) transforms((,newability[produceextra:{g}])) forever
+auto=choice name(blue) transforms((,newability[produceextra:{u}])) forever
+auto=choice name(red) transforms((,newability[produceextra:{r}])) forever
+auto=choice name(black) transforms((,newability[produceextra:{b}])) forever
+auto=choice name(white) transforms((,newability[produceextra:{w}])) forever
 text=Enchant Forest -- As Utopia Sprawl enters the battlefield, choose a color. -- Whenever enchanted Forest is tapped for mana, its controller adds one mana of the chosen color to his or her mana pool (in addition to the mana the land produces).
 mana={G}
 type=Enchantment
@@ -108223,12 +108228,12 @@ subtype=Elemental
 power=7
 toughness=7
 [/card]
-#tappedformana stack...
+#produceextra:selectmana when used acts as an observer so the ability must be on the source since its a mayability of mana not a menuability
 [card]
 name=Verdant Haven
 target=land
 auto=life:2 controller
-auto=teach(land) transforms((,newability[@tappedformana(this):chooseacolor add{chosencolor} chooseend]))
+auto=all(this) transforms((,newability[produceextra:selectmana])) forever
 text=Enchant land -- When Verdant Haven enters the battlefield, you gain 2 life. -- Whenever enchanted land is tapped for mana, its controller adds one mana of any color to his or her mana pool (in addition to the mana the land produces).
 mana={2}{G}
 type=Enchantment

--- a/projects/mtg/build.number.properties
+++ b/projects/mtg/build.number.properties
@@ -1,6 +1,6 @@
 #build.number.properties (normally this file is maintained by build.xml)
 #Sun, 06 May 2012 11:56:35 -0700
 build.major=0
-build.minor=19
-build.point=2
+build.minor=20
+build.point=1
 

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -4800,6 +4800,49 @@ public:
     ~AVanishing();
 };
 
+//Produce Mana when tapped for mana...
+class AProduceMana: public MTGAbility
+{
+public:
+    string ManaDescription;
+    string mana[5];
+
+    AProduceMana(GameObserver* observer, int _id, MTGCardInstance * _source, string _ManaDescription);
+    int receiveEvent(WEvent * event);
+    int produce();
+    const string getMenuText();
+    //virtual ostream& toString(ostream& out) const;
+    AProduceMana * clone() const;
+    ~AProduceMana();
+};
+
+//Produce Mana when a mana is engaged...
+class AEngagedManaAbility: public MTGAbility
+{
+public:
+    string colorname;
+    AEngagedManaAbility(GameObserver* observer, int _id, MTGCardInstance * _source, string _colorname) :
+    MTGAbility(observer, _id, _source)
+    {
+        colorname = _colorname;
+    }
+    int receiveEvent(WEvent * event)
+    {
+        if(WEventEngageMana * isManaProduced = dynamic_cast<WEventEngageMana *> (event))
+        {
+            if ((isManaProduced->card == source) && isManaProduced->color == Constants::GetColorStringIndex(colorname))
+            {
+                source->controller()->getManaPool()->add(Constants::GetColorStringIndex(colorname),1);
+            }
+        }
+        return 1;
+    }
+    AEngagedManaAbility * clone() const
+    {
+        return NEW AEngagedManaAbility(*this);
+    }
+};
+
 //Upkeep Cost
 class AUpkeep: public ActivatedAbility, public NestedAbility
 {
@@ -5970,37 +6013,6 @@ public:
     AEvolveAbility * clone() const
     {
         return NEW AEvolveAbility(*this);
-    }
-};
-
-//ProduceExtra Mana when tapped for mana
-class AProduceExtraAbility: public MTGAbility
-{
-public:
-    string ManaDescription;
-
-    AProduceExtraAbility(GameObserver* observer, int _id, MTGCardInstance * _source, string _ManaDescription) :
-        MTGAbility(observer, _id, _source)
-    {
-        ManaDescription = _ManaDescription;
-    }
-        int receiveEvent(WEvent * event)
-        {
-            if(WEventCardTappedForMana * isTappedForMana = dynamic_cast<WEventCardTappedForMana *> (event))
-            {
-                if ((isTappedForMana->card == source) && (isTappedForMana->card->controller() == source->controller()))
-                {
-                    AManaProducer *amp = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(ManaDescription,NULL,source), NULL, 0,"",false);
-                    amp->resolve();
-                    SAFE_DELETE(amp);
-                }
-            }
-            return 1;
-        }
-
-    AProduceExtraAbility * clone() const
-    {
-        return NEW AProduceExtraAbility(*this);
     }
 };
 

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -4871,6 +4871,78 @@ AVanishing::~AVanishing()
 {
 }
 
+//Produce Mana
+AProduceMana::AProduceMana(GameObserver* observer, int _id, MTGCardInstance * _source, string ManaDescription) :
+MTGAbility(observer, _id, source),ManaDescription(ManaDescription)
+{
+    source = _source;
+    mana[0] = "{g}"; mana[1] = "{u}"; mana[2] = "{r}"; mana[3] = "{b}"; mana[4] = "{w}";
+}
+
+int AProduceMana::receiveEvent(WEvent * event)
+{
+    if(WEventCardTappedForMana * isTappedForMana = dynamic_cast<WEventCardTappedForMana *> (event))
+    {
+        if ((isTappedForMana->card == source)||(isTappedForMana->card == source->target && ManaDescription == "selectmana"))
+            produce();
+    }
+    return 1;
+}
+
+int AProduceMana::produce()
+{
+    if(ManaDescription == "selectmana")
+    {//I tried menu ability and vector<MTGAbility*abi> to have a shorter code but it crashes wagic at end of turn...
+     //The may ability on otherhand works but the ability is cumulative...
+     //This must be wrapped on menuability so we can use it on successions...
+        AManaProducer *ap0 = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(mana[0],NULL,source), NULL, 0,"",false);
+        MayAbility *mw0 = NEW MayAbility(game, game->mLayers->actionLayer()->getMaxId(), ap0, source,true);
+        MTGAbility *ga0 = NEW GenericAddToGame(game, game->mLayers->actionLayer()->getMaxId(), source,NULL,mw0);
+
+        AManaProducer *ap1 = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(mana[1],NULL,source), NULL, 0,"",false);
+        MayAbility *mw1 = NEW MayAbility(game, game->mLayers->actionLayer()->getMaxId(), ap1, source,true);
+        MTGAbility *ga1 = NEW GenericAddToGame(game, game->mLayers->actionLayer()->getMaxId(), source,NULL,mw1);
+
+        AManaProducer *ap2 = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(mana[2],NULL,source), NULL, 0,"",false);
+        MayAbility *mw2 = NEW MayAbility(game, game->mLayers->actionLayer()->getMaxId(), ap2, source,true);
+        MTGAbility *ga2 = NEW GenericAddToGame(game, game->mLayers->actionLayer()->getMaxId(), source,NULL,mw2);
+
+        AManaProducer *ap3 = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(mana[3],NULL,source), NULL, 0,"",false);
+        MayAbility *mw3 = NEW MayAbility(game, game->mLayers->actionLayer()->getMaxId(), ap3, source,true);
+        MTGAbility *ga3 = NEW GenericAddToGame(game, game->mLayers->actionLayer()->getMaxId(), source,NULL,mw3);
+
+        AManaProducer *ap4 = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(mana[4],NULL,source), NULL, 0,"",false);
+        MayAbility *mw4 = NEW MayAbility(game, game->mLayers->actionLayer()->getMaxId(), ap4, source,true);
+        MTGAbility *ga4 = NEW GenericAddToGame(game, game->mLayers->actionLayer()->getMaxId(), source,NULL,mw4);
+
+        ga0->resolve();
+        ga1->resolve();
+        ga2->resolve();
+        ga3->resolve();
+        ga4->resolve();
+    }
+    else
+    {
+        AManaProducer *amp = NEW AManaProducer(game, game->mLayers->actionLayer()->getMaxId(), source, source->controller(), ManaCost::parseManaCost(ManaDescription,NULL,source), NULL, 0,"",false);
+        amp->resolve();
+    }
+    return 1;
+}
+
+const string AProduceMana::getMenuText()
+{
+    return "Produce Mana";
+}
+
+AProduceMana * AProduceMana::clone() const
+{
+    return NEW AProduceMana(*this);
+}
+
+AProduceMana::~AProduceMana()
+{
+}
+
 //AUpkeep
 AUpkeep::AUpkeep(GameObserver* observer, int _id, MTGCardInstance * card, MTGAbility * a, ManaCost * _cost, int restrictions, int _phase,
         int _once,bool Cumulative) :

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2662,7 +2662,13 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
     //produce additional mana when tapped for mana
     if (s.find("produceextra:") != string::npos)
     {
-        return NEW AProduceExtraAbility(observer, id, card,s.substr(13));
+        return NEW AProduceMana(observer, id, card,s.substr(13));
+    }
+
+    //produce additional mana when a mana is engaged
+    if (s.find("producecolor:") != string::npos)
+    {
+        return NEW AEngagedManaAbility(observer, id, card,s.substr(13));
     }
 
     //reducelife to specific value


### PR DESCRIPTION
producecolor:color look for the mana color when engaged
produceextra:selectmana acts like tappedformana(mytgt) so the ability
must be on the source
produceextra:{color}  ability on the otherhand, the ability must be on
the target