### PR TITLE
fix legend rule

### DIFF
--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -90850,7 +90850,7 @@ toughness=1
 [/card]
 [card]
 name=Skywise Teachings
-auto=@movedto(*[-creature]|mystack):pay[{1}{U}] name(Pay 1U mana) token(Djinn Monk,Creature Djinn Monk,2/2,flying,blue) controller
+auto=@movedto(*[-creature]|mystack):pay({1}{U}) name(Pay 1U mana) token(Djinn Monk,Creature Djinn Monk,2/2,flying,blue) controller
 text=Whenever you cast a noncreature spell, you may pay {1}{U}. If you do, put a 2/2 blue Djinn Monk creature token with flying onto the battlefield.
 mana={3}{U}
 type=Enchantment

--- a/projects/mtg/include/GameApp.h
+++ b/projects/mtg/include/GameApp.h
@@ -73,6 +73,7 @@ public:
     static hgeParticleSystem * Particles[6];
     static bool HasMusic;
     static string systemError;
+    static char mynbcardsStr[512];
     static JMusic* music;
     static string currentMusicFile;
     static void playMusic(string filename = "", bool loop = true);

--- a/projects/mtg/include/GameStateMenu.h
+++ b/projects/mtg/include/GameStateMenu.h
@@ -24,7 +24,6 @@ private:
     float mCreditsYPos;
     int currentState;
     int mVolume;
-    char nbcardsStr[400];
     vector<string> langs;
     vector<string> primitives;
 
@@ -46,7 +45,6 @@ private:
     bool langChoices;
     void runTest(); //!!
     void listPrimitives();
-    void genNbCardsStr(); //computes the contents of nbCardsStr
     void ensureMGuiController(); //creates the MGuiController if it doesn't exist
     string loadRandomWallpaper(); //loads a list of string of textures that can be randolmy shown on the loading screen
 
@@ -66,6 +64,7 @@ public:
 
     int nextSetFolder(const string & root, const string & file); // Retrieves the next directory to have matching file
     void createUsersFirstDeck(int setId);
+    static void genNbCardsStr(); //computes the contents of nbCardsStr
     virtual ostream& toString(ostream& out) const;
 
     enum

--- a/projects/mtg/src/GameApp.cpp
+++ b/projects/mtg/src/GameApp.cpp
@@ -39,6 +39,7 @@ bool GameApp::HasMusic = true;
 JMusic * GameApp::music = NULL;
 string GameApp::currentMusicFile = "";
 string GameApp::systemError = "";
+char GameApp::mynbcardsStr[512] = {0};
 
 vector<JQuadPtr > manaIcons;
 

--- a/projects/mtg/src/GameStateMenu.cpp
+++ b/projects/mtg/src/GameStateMenu.cpp
@@ -164,22 +164,22 @@ void GameStateMenu::genNbCardsStr()
     PlayerData * playerdata = NEW PlayerData(MTGCollection());
     size_t totalUnique =  MTGCollection()->primitives.size();
     size_t totalPrints = MTGCollection()->totalCards();
-
+	
     if (totalUnique != totalPrints)
     {
         if (playerdata && !options[Options::ACTIVE_PROFILE].isDefault())
-            sprintf(nbcardsStr, _("%s: %i cards (%i) (%i unique)").c_str(), options[Options::ACTIVE_PROFILE].str.c_str(),
+            sprintf(GameApp::mynbcardsStr, _("%s: %i cards (%i) (%i unique)").c_str(), options[Options::ACTIVE_PROFILE].str.c_str(),
                             playerdata->collection->totalCards(), totalPrints,totalUnique);
         else
-            sprintf(nbcardsStr, _("%i cards (%i unique)").c_str(),totalPrints,totalUnique);
+            sprintf(GameApp::mynbcardsStr, _("%i cards (%i unique)").c_str(),totalPrints,totalUnique);
     }
     else
     {
         if (playerdata && !options[Options::ACTIVE_PROFILE].isDefault())
-            sprintf(nbcardsStr, _("%s: %i cards (%i)").c_str(), options[Options::ACTIVE_PROFILE].str.c_str(),
+            sprintf(GameApp::mynbcardsStr, _("%s: %i cards (%i)").c_str(), options[Options::ACTIVE_PROFILE].str.c_str(),
                             playerdata->collection->totalCards(), totalPrints);
         else
-            sprintf(nbcardsStr, _("%i cards").c_str(),totalPrints);
+            sprintf(GameApp::mynbcardsStr, _("%i cards").c_str(),totalPrints);
     }
 
     SAFE_DELETE(playerdata);
@@ -730,7 +730,7 @@ void GameStateMenu::RenderTopMenu()
     mFont->SetScale(DEFAULT_MAIN_FONT_SCALE);
     mFont->SetColor(ARGB(128,255,255,255));
     mFont->DrawString(GAME_VERSION, rightTextPos, 5, JGETEXT_RIGHT);
-    mFont->DrawString(nbcardsStr, leftTextPos, 5);
+    mFont->DrawString(GameApp::mynbcardsStr, leftTextPos, 5);
     renderer->FillRect(leftTextPos, 26, 104, 8, ARGB(255, 100, 90, 60));
     renderer->FillRect(leftTextPos + 2, 28, (float)(gamePercentComplete()), 4, ARGB(255,220,200, 125));
     char buf[512];
@@ -964,7 +964,6 @@ ostream& GameStateMenu::toString(ostream& out) const
                  << " ; mCreditsYPos : " << mCreditsYPos
                  << " ; currentState : " << currentState
                  << " ; mVolume : " << mVolume
-                 << " ; nbcardsStr : " << nbcardsStr
                  << " ; mCurrentSetName : " << mCurrentSetName
                  << " ; mCurrentSetFileName : " << mCurrentSetFileName
                  << " ; mReadConf : " << mReadConf

--- a/projects/mtg/src/GameStateOptions.cpp
+++ b/projects/mtg/src/GameStateOptions.cpp
@@ -1,6 +1,7 @@
 #include "PrecompiledHeader.h"
 
 #include "GameStateOptions.h"
+#include "GameStateMenu.h"
 #include "GameApp.h"
 #include "OptionItem.h"
 #include "SimpleMenu.h"
@@ -167,6 +168,7 @@ void GameStateOptions::Update(float dt)
                 JSoundSystem::GetInstance()->SetMusicVolume(options[Options::MUSICVOLUME].number);
                 mParent->DoTransition(TRANSITION_FADE, GAME_STATE_MENU);
                 mState = SHOW_OPTIONS;
+                GameStateMenu::genNbCardsStr();
                 break;
             case WGuiBase::CONFIRM_NEED:
                 optionsTabs->yieldFocus();

--- a/projects/mtg/src/GameStateShop.cpp
+++ b/projects/mtg/src/GameStateShop.cpp
@@ -5,6 +5,7 @@
 
 #include <JRenderer.h>
 #include "GameStateShop.h"
+#include "GameStateMenu.h"
 #include "GameApp.h"
 #include "MTGDeck.h"
 #include "MTGPack.h"
@@ -840,6 +841,7 @@ void GameStateShop::ButtonPressed(int controllerId, int controlId)
         mStage = STAGE_SHOP_SHOP;
         mParent->DoTransition(TRANSITION_FADE, GAME_STATE_MENU);
         save();
+        GameStateMenu::genNbCardsStr();
         break;
     case 14:
         mStage = STAGE_SHOP_TASKS;

--- a/projects/mtg/src/GuiPlay.cpp
+++ b/projects/mtg/src/GuiPlay.cpp
@@ -195,7 +195,7 @@ void GuiPlay::Replace()
     for (iterator it = cards.begin(); it != end_spells; ++it)
         if (!(*it)->card->target)
         {
-            if((!(*it)->card->hasSubtype(Subtypes::TYPE_AURA)|| ((*it)->card->hasSubtype(Subtypes::TYPE_AURA) && (*it)->card->playerTarget)) && !(*it)->card->hasType(Subtypes::TYPE_PLANESWALKER))
+            if((!(*it)->card->hasSubtype(Subtypes::TYPE_AURA)|| ((*it)->card->hasSubtype(Subtypes::TYPE_AURA) && !(*it)->card->playerTarget)) && !(*it)->card->hasType(Subtypes::TYPE_PLANESWALKER))
             {
 				if (mpDuelLayers->getRenderedPlayer() == (*it)->card->controller())
                     ++selfSpellsN;
@@ -231,7 +231,7 @@ void GuiPlay::Replace()
     for (iterator it = cards.begin(); it != end_spells; ++it)
         if (!(*it)->card->target)
         {
-            if((!(*it)->card->hasSubtype(Subtypes::TYPE_AURA)|| ((*it)->card->hasSubtype(Subtypes::TYPE_AURA) && (*it)->card->playerTarget)) && !(*it)->card->hasType(Subtypes::TYPE_PLANESWALKER))
+            if((!(*it)->card->hasSubtype(Subtypes::TYPE_AURA)|| ((*it)->card->hasSubtype(Subtypes::TYPE_AURA) && !(*it)->card->playerTarget)) && !(*it)->card->hasType(Subtypes::TYPE_PLANESWALKER))
             {
                 if (mpDuelLayers->getRenderedPlayer() == (*it)->card->controller())
                     selfSpells.Enstack(*it);

--- a/projects/mtg/src/MTGRules.cpp
+++ b/projects/mtg/src/MTGRules.cpp
@@ -2518,16 +2518,14 @@ int MTGLegendRule::added(MTGCardInstance * card)
         MultiAbility * multi = NEW MultiAbility(game, game->mLayers->actionLayer()->getMaxId(), card, card, NULL);
         for(unsigned int i = 0;i < oldCards.size();i++)
         {
-            AABuryCard *a = NEW AABuryCard(game, game->mLayers->actionLayer()->getMaxId(), card, oldCards[i]);
-            a->menu = "Keep New";
+            AAMover *a = NEW AAMover(game, game->mLayers->actionLayer()->getMaxId(), card, oldCards[i],"ownergraveyard","Keep New");
             a->oneShot = true;
             multi->Add(a);
         }
         multi->oneShot = 1;
         MTGAbility * a1 = multi;
         selection.push_back(a1);
-        AABuryCard *b = NEW AABuryCard(game, game->mLayers->actionLayer()->getMaxId(), card, card);
-        b->menu = "Keep Old";
+        AAMover *b = NEW AAMover(game, game->mLayers->actionLayer()->getMaxId(), card, card,"ownergraveyard","Keep Old");
         b->oneShot = true;
         MTGAbility * b1 = b;
         selection.push_back(b1);


### PR DESCRIPTION
704.5k If a player controls two or more legendary permanents with the
same name, that player
chooses one of them, and the rest are put into their owners’ graveyards.
This is called the
“legend rule.”

bury is destroy without regenerate, so when two legends of the same name
has indestructible, bury will have no effect... I changed it to put into
owners graveyard instead using mover...