### PR TITLE
Bug Fix: Planeswalker Rule & ABlink return to play ability for Aura cards

### DIFF
--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -5271,7 +5271,7 @@ void ABlink::returnCardIntoPlay(MTGCardInstance* _target) {
             return;
         }
 
-        MTGGameZone * inplay = spell->source->owner->game->inPlay;
+        /*MTGGameZone * inplay = spell->source->owner->game->inPlay;
         spell->source->target = NULL;
         for (int i = game->getRandomGenerator()->random()%inplay->nb_cards;;i = game->getRandomGenerator()->random()%inplay->nb_cards)
         {
@@ -5285,7 +5285,16 @@ void ABlink::returnCardIntoPlay(MTGCardInstance* _target) {
                 this->forceDestroy = 1;
                 return;
             }
-        }
+        }*/
+        //replaced with castcard(putinplay)
+        MTGAbility *a = NEW AACastCard(game, game->mLayers->actionLayer()->getMaxId(), Blinker, Blinker,false,false,false,"","Return to Play",false,true);
+        a->oneShot = false;
+        a->canBeInterrupted = false;
+        a->addToGame();
+        SAFE_DELETE(spell);
+        SAFE_DELETE(tc);
+        this->forceDestroy = 1;
+        return;
     }
     spell->source->power = spell->source->origpower;
     spell->source->toughness = spell->source->origtoughness;

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -2566,7 +2566,7 @@ int AACloner::resolve()
             if(_target->pbonus > 0)
                 spell->source->power = _target->power - _target->pbonus;
             else
-                spell->source->power = _target->power + _target->pbonus;
+                spell->source->power = _target->power + abs(_target->pbonus);
             if(_target->tbonus > 0)
             {
                 spell->source->toughness = _target->toughness - _target->tbonus;
@@ -2574,8 +2574,8 @@ int AACloner::resolve()
             }
             else
             {
-                spell->source->toughness = _target->toughness + _target->tbonus;
-                spell->source->life = _target->toughness + _target->tbonus;
+                spell->source->toughness = _target->toughness + abs(_target->tbonus);
+                spell->source->life = _target->toughness + abs(_target->tbonus);
             }
         }
         list<int>::iterator it;

--- a/projects/mtg/src/MTGRules.cpp
+++ b/projects/mtg/src/MTGRules.cpp
@@ -2529,7 +2529,7 @@ int MTGLegendRule::added(MTGCardInstance * card)
         b->oneShot = true;
         MTGAbility * b1 = b;
         selection.push_back(b1);
-        MTGAbility * menuChoice = NEW MenuAbility(game, game->mLayers->actionLayer()->getMaxId(), card, card,true,selection,card->controller(),"Choose Legend");
+        MTGAbility * menuChoice = NEW MenuAbility(game, game->mLayers->actionLayer()->getMaxId(), card, card,true,selection,card->controller(),"Legendary Rule");
         menuChoice->addToGame();
     }
     return 1;
@@ -2593,20 +2593,18 @@ int MTGPlaneWalkerRule::added(MTGCardInstance * card)
         MultiAbility * multi = NEW MultiAbility(game,game->mLayers->actionLayer()->getMaxId(), card, card, NULL);
         for(unsigned int i = 0;i < oldCards.size();i++)
         {
-            AABuryCard *a = NEW AABuryCard(game, game->mLayers->actionLayer()->getMaxId(), card, oldCards[i]);
-            a->menu = "Keep New";
+            AAMover *a = NEW AAMover(game, game->mLayers->actionLayer()->getMaxId(), card, oldCards[i],"ownergraveyard","Keep New");
             a->oneShot = true;
             multi->Add(a);
         }
         multi->oneShot = 1;
         MTGAbility * a1 = multi;
         selection.push_back(a1);
-        AABuryCard *b = NEW AABuryCard(game, game->mLayers->actionLayer()->getMaxId(), card, card);
-        b->menu = "Keep Old";
+        AAMover *b = NEW AAMover(game, game->mLayers->actionLayer()->getMaxId(), card, card,"ownergraveyard","Keep Old");
         b->oneShot = true;
         MTGAbility * b1 = b;
         selection.push_back(b1);
-        MTGAbility * menuChoice = NEW MenuAbility(game, game->mLayers->actionLayer()->getMaxId(), card, card,true,selection,card->controller(),"Choose Planeswalker");
+        MTGAbility * menuChoice = NEW MenuAbility(game, game->mLayers->actionLayer()->getMaxId(), card, card,true,selection,card->controller(),"Planeswalker Rule");
         menuChoice->addToGame();
     }
     return 1;


### PR DESCRIPTION
704.5j If a player controls two or more planeswalkers that share a planeswalker type, that player
chooses one of them, and the rest are put into their owners’ graveyards. This is called the
“planeswalker uniqueness rule.”