### PR TITLE
Force Mounting 2

### DIFF
--- a/projects/mtg/bin/Res/sets/primitives/mtg.txt
+++ b/projects/mtg/bin/Res/sets/primitives/mtg.txt
@@ -41250,6 +41250,17 @@ mana={1}{B}
 type=Instant
 [/card]
 [card]
+name=Goham Djinn
+auto={1}{B}:regenerate
+auto=this(variable{commonblack}>0) -2/-2
+text={1}{B}: Regenerate Goham Djinn. -- Goham Djinn gets -2/-2 as long as black is the most common color among all permanents or is tied for most common.
+mana={5}{B}
+type=Creature
+subtype=Djinn
+power=5
+toughness=5
+[/card]
+[card]
 name=Gold Myr
 auto={T}:Add{W}
 text={T}: Add {W} to your mana pool.
@@ -43934,6 +43945,17 @@ auto={T(creature|mybattlefield)}:deplete:1 target(player)
 text=Tap an untapped creature you control: Target player puts the top card of his or her library into his or her graveyard.
 mana={6}
 type=Artifact
+[/card]
+[card]
+name=Halam Djinn
+abilities=haste
+auto=this(variable{commonred}>0) -2/-2
+text=Haste -- Halam Djinn gets -2/-2 as long as red is the most common color among all permanents or is tied for most common.
+mana={5}{R}
+type=Creature
+subtype=Djinn
+power=6
+toughness=5
 [/card]
 [card]
 name=Halberdier
@@ -82616,6 +82638,17 @@ text=Ruins of Trokair enters the battlefield tapped. -- {T}: Add {W} to your man
 type=Land
 [/card]
 [card]
+name=Ruham Djinn
+abilities=first strike
+auto=this(variable{commonwhite}>0) -2/-2
+text=First strike --  -- Ruham Djinn gets -2/-2 as long as white is the most common color among all permanents or is tied for most common.
+mana={5}{W}
+type=Creature
+subtype=Djinn
+power=5
+toughness=5
+[/card]
+[card]
 name=Ruhan of the Fomori
 abilities=mustattack
 text=At the beginning of combat on your turn, choose an opponent at random. Ruhan of the Fomori attacks that player this combat if able.
@@ -98156,6 +98189,17 @@ auto={S}:lord(creature|opponentBattlefield) -1/-1  && lord(creature|opponentBatt
 text=Sacrifice Suicidal Charge: Creatures your opponents control get -1/-1 until end of turn. Those creatures attack this turn if able.
 mana={3}{B}{R}
 type=Enchantment
+[/card]
+[card]
+name=Sulam Djinn
+abilities=trample
+auto=this(variable{commongreen}>0) -2/-2
+text=Trample -- Sulam Djinn gets -2/-2 as long as green is the most common color among all permanents or is tied for most common.
+mana={5}{G}
+type=Creature
+subtype=Djinn
+power=6
+toughness=6
 [/card]
 [card]
 name=Suleiman's Legacy
@@ -116488,6 +116532,17 @@ type=Legendary Creature
 subtype=Demon Spirit
 power=5
 toughness=5
+[/card]
+[card]
+name=Zanam Djinn
+abilities=flying
+auto=this(variable{commonblue}>0) -2/-2
+text=Flying -- Zanam Djinn gets -2/-2 as long as blue is the most common color among all permanents or is tied for most common.
+mana={5}{U}
+type=Creature
+subtype=Djinn
+power=5
+toughness=6
 [/card]
 [card]
 name=Zanikev Locust

--- a/projects/mtg/bin/Res/sets/primitives/unsupported.txt
+++ b/projects/mtg/bin/Res/sets/primitives/unsupported.txt
@@ -8873,15 +8873,6 @@ type=Legendary Artifact
 subtype=Equipment
 [/card]
 [card]
-name=Goham Djinn
-text={1}{B}: Regenerate Goham Djinn. -- Goham Djinn gets -2/-2 as long as black is the most common color among all permanents or is tied for most common.
-mana={5}{B}
-type=Creature
-subtype=Djinn
-power=5
-toughness=5
-[/card]
-[card]
 name=Golden Wish
 text=You may choose an artifact or enchantment card you own from outside the game, reveal that card, and put it into your hand. Exile Golden Wish.
 mana={3}{W}{W}
@@ -9456,15 +9447,6 @@ type=Legendary Creature
 subtype=Human Wizard
 power=2
 toughness=4
-[/card]
-[card]
-name=Halam Djinn
-text=Haste -- Halam Djinn gets -2/-2 as long as red is the most common color among all permanents or is tied for most common.
-mana={5}{R}
-type=Creature
-subtype=Djinn
-power=6
-toughness=5
 [/card]
 [card]
 name=Halfdane
@@ -19004,15 +18986,6 @@ power=2
 toughness=3
 [/card]
 [card]
-name=Ruham Djinn
-text=First strike --  -- Ruham Djinn gets -2/-2 as long as white is the most common color among all permanents or is tied for most common.
-mana={5}{W}
-type=Creature
-subtype=Djinn
-power=5
-toughness=5
-[/card]
-[card]
 name=Ruin Processor
 text=When you cast Ruin Processor, you may put a card an opponent owns from exile into that player's graveyard. If you do, you gain 5 life.
 mana={7}
@@ -22537,15 +22510,6 @@ name=Suffocation
 text=Cast Suffocation only if you were dealt damage this turn by a red instant or sorcery spell. -- Suffocation deals 4 damage to the controller of the last red instant or sorcery spell that dealt damage to you this turn. -- Draw a card at the beginning of the next turn's upkeep.
 mana={1}{U}
 type=Instant
-[/card]
-[card]
-name=Sulam Djinn
-text=Trample -- Sulam Djinn gets -2/-2 as long as green is the most common color among all permanents or is tied for most common.
-mana={5}{G}
-type=Creature
-subtype=Djinn
-power=6
-toughness=6
 [/card]
 [card]
 name=Sulfuric Vapors
@@ -26496,15 +26460,6 @@ type=Creature
 subtype=Elf Wizard
 power=2
 toughness=2
-[/card]
-[card]
-name=Zanam Djinn
-text=Flying -- Zanam Djinn gets -2/-2 as long as blue is the most common color among all permanents or is tied for most common.
-mana={5}{U}
-type=Creature
-subtype=Djinn
-power=5
-toughness=6
 [/card]
 [card]
 name=Zealous Inquisitor

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -425,6 +425,26 @@ private:
         {
             intValue = card->imprintW;
         }
+        else if (s == "commongreen")
+        {
+            intValue = mostCommonColor(Constants::MTG_COLOR_GREEN, card);
+        }
+        else if (s == "commonblue")
+        {
+            intValue = mostCommonColor(Constants::MTG_COLOR_BLUE, card);
+        }
+        else if (s == "commonred")
+        {
+            intValue = mostCommonColor(Constants::MTG_COLOR_RED, card);
+        }
+        else if (s == "commonblack")
+        {
+            intValue = mostCommonColor(Constants::MTG_COLOR_BLACK, card);
+        }
+        else if (s == "commonwhite")
+        {
+            intValue = mostCommonColor(Constants::MTG_COLOR_WHITE, card);
+        }
         else if (s == "targetedcurses")
         {
             if(card->playerTarget)
@@ -773,6 +793,36 @@ public:
             if(zone->cards[i]->name == name)
                 count += 1;
         return count;
+    }
+
+    int countCardsInPlaybyColor(int color, GameObserver * observer)
+    {
+        int count = 0;
+        for (int i = 0; i < 2; i++)
+        {
+            for( int j= 0; j < observer->players[i]->inPlay()->nb_cards; j++)
+                if(observer->players[i]->inPlay()->cards[j]->hasColor(color))
+                    count += 1;
+        }
+        return count;
+    }
+
+    int mostCommonColor(int color, MTGCardInstance * card)
+    {
+        int maxColor = 0;
+        vector<int> colors;
+
+        for(int i = 1; i < 6; i++)
+            colors.push_back( countCardsInPlaybyColor(i, card->getObserver()) );
+        
+        for(int j = 0; j < 5; j++)
+            if ( colors[j] > maxColor )
+                maxColor = colors[j];
+
+        if (countCardsInPlaybyColor(color, card->getObserver()) >= maxColor && maxColor > 0)
+            return 1;
+
+        return 0;
     }
 
     int countCardTypeinZone(string type, MTGGameZone * zone)


### PR DESCRIPTION
Force mounting for Newer Android versions... If device is rooted then the storage selection would be on the root of Internal SD (Emulated or not) and root of Secondary Storage (External SD) if it exists. If the device is stock and its Android version is 4.1 (JellyBean and above), use wagic app folder (Android/data/net.wagic.app/files) and put the resource (Wagic/Res) there manually. The catch is when the apk is uninstalled, it deletes that folder.