### PR TITLE
try to fix failed logic here

### DIFF
--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -1324,7 +1324,7 @@ int AACopier::resolve()
         source->copiedID = _target->getMTGId();
         source->modifiedbAbi = _target->modifiedbAbi;
         source->origbasicAbilities = _target->origbasicAbilities;
-        source->basicAbilities = _target->basicAbilities;
+        source->basicAbilities = _target->origbasicAbilities;
         if(_target->isMorphed)
         {
             source->power = 2;
@@ -3696,7 +3696,7 @@ int AACloner::resolve()
             spell->source->addType(*it);
         }
         spell->source->modifiedbAbi = _target->modifiedbAbi;
-        spell->source->origbasicAbilities = _target->origbasicAbilities;
+        spell->source->basicAbilities = _target->origbasicAbilities;
         delete spell;
     }
     return 1;

--- a/projects/mtg/src/GameObserver.cpp
+++ b/projects/mtg/src/GameObserver.cpp
@@ -941,12 +941,12 @@ void GameObserver::gameStateBasedEffects()
                         p->game->putInExile(c);
 
                     }
-                }
+                }/*
                 if(c->modifiedbAbi > 0)
                 {
                     c->modifiedbAbi = 0;
                     c->basicAbilities = c->origbasicAbilities;
-                }
+                }*///disabled this failed logic I introduce... when copying/cloning a card copy orig basic abilities...
                 if(nbcards > z->nb_cards)
                 {
                     t = 0;

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -88,7 +88,7 @@ void MTGCardInstance::copy(MTGCardInstance * card)
     MTGCard * source = card->model;
     CardPrimitive * data = source->data;
 
-    basicAbilities = card->basicAbilities;
+    basicAbilities = card->origbasicAbilities;
     origbasicAbilities = card->origbasicAbilities;
     modifiedbAbi = card->modifiedbAbi;
     for (size_t i = 0; i < data->types.size(); i++)


### PR DESCRIPTION
I added this but this is not the correct way of removing temporary abilities. I'm removing this becuase it overrides other "modified abilties". Example scenario you have "Always Watching" in play that grants vigilance, Then you cast "Aerial Maneuver" that grants flying to a creature in play. At end of turn, The "Vigilance" is removed along with "Flying" and "First Strike"
![card1](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=409737&type=card)![card2](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=366294&type=card)