### PR TITLE
tnum:number parameter for token images

### DIFF
--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -3547,6 +3547,7 @@ public:
     vector<MTGAbility *> currentAbilities;
     MTGAbility * andAbility;
     Player * tokenReciever;
+    string cID;
     //by id
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, int tokenId,string starfound, WParsedInt * multiplier = NULL,
         int who = 0,bool aLivingWeapon = false) :
@@ -3557,6 +3558,7 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
+        cID = "";
     }
     //by name, card still require valid card.dat info, this just makes the primitive code far more readable. token(Eldrazi scion) instead of token(-1234234)...
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string cardName, string starfound, WParsedInt * multiplier = NULL,
@@ -3569,10 +3571,11 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
+        cID = "";
     }
     //by construction
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string sname, string stypes, int _power, int _toughness,
-        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "") :
+        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "", string tnum = "") :
     ActivatedAbility(observer, _id, _source, _cost, 0),sabilities(sabilities),starfound(starfound), multiplier(multiplier), who(_who),aLivingWeapon(aLivingWeapon),spt(spt)
     {
         power = _power;
@@ -3582,6 +3585,7 @@ public:
         aType = MTGAbility::STANDARD_TOKENCREATOR;
         battleReady = false;
         andAbility = NULL;
+        cID = tnum;
         if (!multiplier) this->multiplier = NEW WParsedInt(1);
         //TODO this is a copy/past of other code that's all around the place, everything should be in a dedicated parser class;
 
@@ -3668,6 +3672,16 @@ public:
             else
             {
                 myToken = NEW Token(name, source, power, toughness);
+                if(!cID.empty())
+                {
+                    string customId = "";
+                    ostringstream tokID;
+                    tokID << abs(myToken->getId());
+                    customId.append(""+tokID.str()+cID);
+                    customId = cReplaceString(customId," ","");
+                    WParsedInt newID(customId, NULL, source);
+                    myToken->setMTGId(-newID.getValue());
+                }
                 list<int>::iterator it;
                 for (it = types.begin(); it != types.end(); it++)
                 {

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -3547,7 +3547,6 @@ public:
     vector<MTGAbility *> currentAbilities;
     MTGAbility * andAbility;
     Player * tokenReciever;
-    string cID;
     //by id
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, int tokenId,string starfound, WParsedInt * multiplier = NULL,
         int who = 0,bool aLivingWeapon = false) :
@@ -3558,7 +3557,6 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
-        cID = "";
     }
     //by name, card still require valid card.dat info, this just makes the primitive code far more readable. token(Eldrazi scion) instead of token(-1234234)...
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string cardName, string starfound, WParsedInt * multiplier = NULL,
@@ -3571,11 +3569,10 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
-        cID = "";
     }
     //by construction
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string sname, string stypes, int _power, int _toughness,
-        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "", string tnum = "") :
+        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "") :
     ActivatedAbility(observer, _id, _source, _cost, 0),sabilities(sabilities),starfound(starfound), multiplier(multiplier), who(_who),aLivingWeapon(aLivingWeapon),spt(spt)
     {
         power = _power;
@@ -3585,7 +3582,6 @@ public:
         aType = MTGAbility::STANDARD_TOKENCREATOR;
         battleReady = false;
         andAbility = NULL;
-        cID = tnum;
         if (!multiplier) this->multiplier = NEW WParsedInt(1);
         //TODO this is a copy/past of other code that's all around the place, everything should be in a dedicated parser class;
 
@@ -3687,16 +3683,6 @@ public:
                 }
             }
             string tokenText = "";
-            if(!cID.empty())
-            {
-                string customId = "";
-                ostringstream tokID;
-                tokID << abs(myToken->getId());
-                customId.append(""+tokID.str()+cID);
-                customId = cReplaceString(customId," ","");
-                WParsedInt newID(customId, NULL, source);
-                myToken->setMTGId(-newID.getValue());
-            }
             if(sabilities.find("token(") == string::npos)
             {
                 tokenText = "(";

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -3547,6 +3547,7 @@ public:
     vector<MTGAbility *> currentAbilities;
     MTGAbility * andAbility;
     Player * tokenReciever;
+    string cID;
     //by id
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, int tokenId,string starfound, WParsedInt * multiplier = NULL,
         int who = 0,bool aLivingWeapon = false) :
@@ -3557,6 +3558,7 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
+        cID = "";
     }
     //by name, card still require valid card.dat info, this just makes the primitive code far more readable. token(Eldrazi scion) instead of token(-1234234)...
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string cardName, string starfound, WParsedInt * multiplier = NULL,
@@ -3569,10 +3571,11 @@ public:
         if (card) name = card->data->getName();
         battleReady = false;
         andAbility = NULL;
+        cID = "";
     }
     //by construction
     ATokenCreator(GameObserver* observer, int _id, MTGCardInstance * _source, Targetable *, ManaCost * _cost, string sname, string stypes, int _power, int _toughness,
-        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "") :
+        string sabilities, string starfound,WParsedInt * multiplier = NULL, int _who = 0,bool aLivingWeapon = false,string spt = "", string tnum = "") :
     ActivatedAbility(observer, _id, _source, _cost, 0),sabilities(sabilities),starfound(starfound), multiplier(multiplier), who(_who),aLivingWeapon(aLivingWeapon),spt(spt)
     {
         power = _power;
@@ -3582,6 +3585,7 @@ public:
         aType = MTGAbility::STANDARD_TOKENCREATOR;
         battleReady = false;
         andAbility = NULL;
+        cID = tnum;
         if (!multiplier) this->multiplier = NEW WParsedInt(1);
         //TODO this is a copy/past of other code that's all around the place, everything should be in a dedicated parser class;
 
@@ -3683,6 +3687,16 @@ public:
                 }
             }
             string tokenText = "";
+            if(!cID.empty())
+            {
+                string customId = "";
+                ostringstream tokID;
+                tokID << abs(myToken->getId());
+                customId.append(""+tokID.str()+cID);
+                customId = cReplaceString(customId," ","");
+                WParsedInt newID(customId, NULL, source);
+                myToken->setMTGId(-newID.getValue());
+            }
             if(sabilities.find("token(") == string::npos)
             {
                 tokenText = "(";

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2420,15 +2420,21 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string sname = tokenParameters[0];
         string stypes = tokenParameters[1];
         string spt = tokenParameters[2];
-
+        string cID = "";
         //reconstructing string abilities from the split version,
         // then we re-split it again in the token constructor,
         // this needs to be improved
         string sabilities = (tokenParameters.size() > 3)? tokenParameters[3] : "";
         for (size_t i = 4; i < tokenParameters.size(); ++i)
         {
-            sabilities.append(",");
-            sabilities.append(tokenParameters[i]);
+            string tnum = tokenParameters[i];
+            if(tnum.find("tnum:"))
+                cID = cReplaceString(tnum,"tnum:","");
+            else
+            {
+                sabilities.append(",");
+                sabilities.append(tokenParameters[i]);
+            }
         }
         int value = 0;
         if (spt.find("xx/xx") != string::npos)
@@ -2441,7 +2447,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         
         ATokenCreator * tok = NEW ATokenCreator(
             observer, id, card,target, NULL, sname, stypes, power + value, toughness + value,
-            sabilities, starfound, multiplier, who, aLivingWeapon, spt);
+            sabilities, starfound, multiplier, who, aLivingWeapon, spt, cID);
         tok->oneShot = 1;
         if(aLivingWeapon)
             tok->forceDestroy = 1;

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2394,7 +2394,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string tokenDesc = splitToken[1];
         vector<string> tokenParameters = split(tokenDesc, ',');
         //lets try finding a token by card name.
-        if (splitToken[1].size() && tokenParameters.size() <3)//names with "," should work like token(Akuta, Born of Ash) 
+        if (splitToken[1].size() && tokenParameters.size() ==1)
         {
             string cardName = splitToken[1];
             MTGCard * safetycard = MTGCollection()->getCardByName(cardName);

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2420,21 +2420,15 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string sname = tokenParameters[0];
         string stypes = tokenParameters[1];
         string spt = tokenParameters[2];
-        string cID = "";
+
         //reconstructing string abilities from the split version,
         // then we re-split it again in the token constructor,
         // this needs to be improved
         string sabilities = (tokenParameters.size() > 3)? tokenParameters[3] : "";
         for (size_t i = 4; i < tokenParameters.size(); ++i)
         {
-            string tnum = tokenParameters[i];
-            if(tnum.find("tnum:"))
-                cID = cReplaceString(tnum,"tnum:","");
-            else
-            {
-                sabilities.append(",");
-                sabilities.append(tokenParameters[i]);
-            }
+            sabilities.append(",");
+            sabilities.append(tokenParameters[i]);
         }
         int value = 0;
         if (spt.find("xx/xx") != string::npos)
@@ -2447,7 +2441,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         
         ATokenCreator * tok = NEW ATokenCreator(
             observer, id, card,target, NULL, sname, stypes, power + value, toughness + value,
-            sabilities, starfound, multiplier, who, aLivingWeapon, spt, cID);
+            sabilities, starfound, multiplier, who, aLivingWeapon, spt);
         tok->oneShot = 1;
         if(aLivingWeapon)
             tok->forceDestroy = 1;

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2394,7 +2394,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string tokenDesc = splitToken[1];
         vector<string> tokenParameters = split(tokenDesc, ',');
         //lets try finding a token by card name.
-        if (splitToken[1].size() && tokenParameters.size() ==1)
+        if (splitToken[1].size() && tokenParameters.size() <3)
         {
             string cardName = splitToken[1];
             MTGCard * safetycard = MTGCollection()->getCardByName(cardName);
@@ -2420,7 +2420,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string sname = tokenParameters[0];
         string stypes = tokenParameters[1];
         string spt = tokenParameters[2];
-
+        string cID = "";
         //reconstructing string abilities from the split version,
         // then we re-split it again in the token constructor,
         // this needs to be improved
@@ -2429,6 +2429,12 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         {
             sabilities.append(",");
             sabilities.append(tokenParameters[i]);
+        }
+        if(sabilities.find(",tnum:") != string::npos)
+        {
+            size_t begins = sabilities.find(",tnum:");
+            cID = sabilities.substr(begins+6);
+            sabilities = cReplaceString(sabilities,",tnum:"+cID,"");
         }
         int value = 0;
         if (spt.find("xx/xx") != string::npos)
@@ -2441,7 +2447,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         
         ATokenCreator * tok = NEW ATokenCreator(
             observer, id, card,target, NULL, sname, stypes, power + value, toughness + value,
-            sabilities, starfound, multiplier, who, aLivingWeapon, spt);
+            sabilities, starfound, multiplier, who, aLivingWeapon, spt, cID);
         tok->oneShot = 1;
         if(aLivingWeapon)
             tok->forceDestroy = 1;

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2394,7 +2394,7 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         string tokenDesc = splitToken[1];
         vector<string> tokenParameters = split(tokenDesc, ',');
         //lets try finding a token by card name.
-        if (splitToken[1].size() && tokenParameters.size() ==1)
+        if (splitToken[1].size() && tokenParameters.size() <3)//names with "," should work like token(Akuta, Born of Ash) 
         {
             string cardName = splitToken[1];
             MTGCard * safetycard = MTGCollection()->getCardByName(cardName);

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -149,20 +149,6 @@ void MTGCardInstance::copy(MTGCardInstance * card)
     backupTargets = this->backupTargets;
     storedCard = oldStored;
     miracle = false;
-    if (card->TokenAndAbility)
-    {
-        MTGAbility * andAbilityClone = card->TokenAndAbility->clone();
-        andAbilityClone->target = this;
-        if(card->TokenAndAbility->oneShot)
-        {
-            andAbilityClone->resolve();
-            SAFE_DELETE(andAbilityClone);
-        }
-        else
-        {
-            andAbilityClone->addToGame();
-        }
-    }
 }
 
 MTGCardInstance::~MTGCardInstance()


### PR DESCRIPTION
you can specify tnum:number on token parameters and it will concatenate the default token id and the specified number. example: token(Saproling, Creature Saproling, 1/1, green, tnum:15) if the source id is 12345, the default token id will be -12345, concat tnum, final id will be -1234515 and the game will try to find the image 1234515t.jpg

example card Fable of Wolf and Owl

> [card]
> name=Fable of Wolf and Owl
> auto=@movedTo(*[green]|mystack):may token(Wolf,Creature Wolf,2/2,green,tnum:11)
> auto=@movedTo(*[blue]|mystack):may token(Bird,Creature Bird,1/1,flying,blue,tnum:12)
> text=Whenever you cast a green spell, you may put a 2/2 green Wolf creature token onto the battlefield. -- Whenever you cast a blue spell, you may put a 1/1 blue Bird creature token with flying onto the battlefield.
> mana={3}{GU}{GU}{GU}
> type=Enchantment
> [/card]

![Fable](http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=152087&type=card)