### PR TITLE
border & mask

### DIFF
--- a/projects/mtg/include/CardGui.h
+++ b/projects/mtg/include/CardGui.h
@@ -36,7 +36,7 @@ protected:
     static void RenderBig(MTGCard * card, const Pos& pos, bool thumb = false, bool noborder = false, bool smallerscale = false, bool ingame = false);
 
     static void RenderCountersBig(MTGCard * card, const Pos& pos, int drawMode = DrawMode::kNormal);
-    static void AlternateRender(MTGCard * card, const Pos& pos);
+    static void AlternateRender(MTGCard * card, const Pos& pos, bool noborder = false, bool smallerscale = false);
     static void TinyCropRender(MTGCard * card, const Pos& pos, JQuad * quad);
     static string FormattedData (string data, string replace, string value);
     static bool FilterCard (MTGCard * card,string filter);


### PR DESCRIPTION
fix shadows not covering white bordered cards, replace mask to use "white" quad so they cover the card render nicely. Add borders to Alternate render (text)