### PR TITLE
fix halfup logic when used on negation

### DIFF
--- a/projects/mtg/bin/Res/missing_cards_by_sets/DGM.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/DGM.txt
@@ -1,0 +1,228 @@
+[card]
+name=Alive // Well
+text=Put a 3/3 green Centaur creature token onto the battlefield. --  //  -- You gain 2 life for each creature you control. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={3}{G} // {W}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Armed // Dangerous
+text=Target creature gets +1/+1 and gains double strike until end of turn. --  //  -- All creatures able to block target creature this turn do so. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{R} // {3}{G}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Beck // Call
+text=Whenever a creature enters the battlefield this turn, you may draw a card. --  //  -- Put four 1/1 white Bird creature tokens with flying onto the battlefield. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={G}{U} // {4}{W}{U}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Boros Battleshaper
+text=At the beginning of each combat, up to one target creature attacks or blocks this combat if able and up to one target creature can't attack or block this combat.
+mana={5}{R}{W}
+type=Creature
+subtype=Minotaur Soldier
+power=5
+toughness=5
+[/card]
+[card]
+name=Breaking // Entering
+text=Target player puts the top eight cards of his or her library into his or her graveyard. --  //  -- Put a creature card from a graveyard onto the battlefield under your control. It gains haste until end of turn. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={U}{B} // {4}{B}{R}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Catch // Release
+text=Gain control of target permanent until end of turn. Untap it. It gains haste until end of turn. --  //  -- Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{U}{R} // {4}{R}{W}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Council of the Absolute
+text=As Council of the Absolute enters the battlefield, name a card other than a creature or land card. -- Your opponents can't cast cards with the chosen name. -- Spells with the chosen name you cast cost {2} less to cast.
+mana={2}{W}{U}
+type=Creature
+subtype=Human Advisor
+power=2
+toughness=4
+[/card]
+[card]
+name=Deadbridge Chant
+text=When Deadbridge Chant enters the battlefield, put the top ten cards of your library into your graveyard. -- At the beginning of your upkeep, choose a card at random in your graveyard. If it's a creature card, put it onto the battlefield. Otherwise, put it into your hand.
+mana={4}{B}{G}
+type=Enchantment
+[/card]
+[card]
+name=Down // Dirty
+text=Target player discards two cards. --  //  -- Return target card from your graveyard to your hand. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={3}{B} // {2}{G}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Dragonshift
+text=Until end of turn, target creature you control becomes a 4/4 blue and red Dragon, loses all abilities, and gains flying. -- Overload {3}{U}{U}{R}{R} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of "target" with "each.")
+mana={1}{U}{R}
+type=Instant
+[/card]
+[card]
+name=Far // Away
+text=Return target creature to its owner's hand. --  //  -- Target player sacrifices a creature. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{U} // {2}{B}
+type=Instant // Instant
+[/card]
+[card]
+name=Flesh // Blood
+text=Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled. --  //  -- Target creature you control deals damage equal to its power to target creature or player. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={3}{B}{G} // {R}{G}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Give // Take
+text=Put three +1/+1 counters on target creature. --  //  -- Remove all +1/+1 counters from target creature you control. Draw that many cards. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={2}{G} // {2}{U}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Goblin Test Pilot
+text=Flying -- {T}: Goblin Test Pilot deals 2 damage to target creature or player chosen at random.
+mana={1}{U}{R}
+type=Creature
+subtype=Goblin Wizard
+power=0
+toughness=2
+[/card]
+[card]
+name=Hidden Strings
+text=You may tap or untap target permanent, then you may tap or untap another target permanent. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={1}{U}
+type=Sorcery
+[/card]
+[card]
+name=Hired Torturer
+text=Defender -- {3}{B}, {T}: Target opponent loses 2 life, then reveals a card at random from his or her hand.
+mana={2}{B}
+type=Creature
+subtype=Human Rogue
+power=2
+toughness=3
+[/card]
+[card]
+name=Krasis Incubation
+text=Enchant creature -- Enchanted creature can't attack or block, and its activated abilities can't be activated. -- {1}{G}{U}, Return Krasis Incubation to its owner's hand: Put two +1/+1 counters on enchanted creature.
+mana={2}{G}{U}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Maze's End
+text=Maze's End enters the battlefield tapped. -- {T}: Add {1} to your mana pool. -- {3}, {T}, Return Maze's End to its owner's hand: Search your library for a Gate card, put it onto the battlefield, then shuffle your library. If you control ten or more Gates with different names, you win the game.
+type=Land
+[/card]
+[card]
+name=Melek, Izzet Paragon
+text=Play with the top card of your library revealed. -- You may cast the top card of your library if it's an instant or sorcery card. -- Whenever you cast an instant or sorcery spell from your library, copy it. You may choose new targets for the copy.
+mana={4}{U}{R}
+type=Legendary Creature
+subtype=Weird Wizard
+power=2
+toughness=4
+[/card]
+[card]
+name=Notion Thief
+text=Flash -- If an opponent would draw a card except the first one he or she draws in each of his or her draw steps, instead that player skips that draw and you draw a card.
+mana={2}{U}{B}
+type=Creature
+subtype=Human Rogue
+power=3
+toughness=1
+[/card]
+[card]
+name=Plasm Capture
+text=Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors to your mana pool, where X is that spell's converted mana cost.
+mana={G}{G}{U}{U}
+type=Instant
+[/card]
+[card]
+name=Possibility Storm
+text=Whenever a player casts a spell from his or her hand, that player exiles it, then exiles cards from the top of his or her library until he or she exiles a card that shares a card type with it. That player may cast that card without paying its mana cost. Then he or she puts all cards exiled with Possibility Storm on the bottom of his or her library in a random order.
+mana={3}{R}{R}
+type=Enchantment
+[/card]
+[card]
+name=Profit // Loss
+text=Creatures you control get +1/+1 until end of turn. --  //  -- Creatures your opponents control get -1/-1 until end of turn. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{W} // {2}{B}
+type=Instant // Instant
+[/card]
+[card]
+name=Protect // Serve
+text=Target creature gets +2/+4 until end of turn. --  //  -- Target creature gets -6/-0 until end of turn. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={2}{W} // {1}{U}
+type=Instant // Instant
+[/card]
+[card]
+name=Ready // Willing
+text=Creatures you control are indestructible this turn. Untap each creature you control. --  //  -- Creatures you control gain deathtouch and lifelink until end of turn. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{G}{W} // {1}{W}{B}
+type=Instant // Instant
+[/card]
+[card]
+name=Renegade Krasis
+text=Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.) -- Whenever Renegade Krasis evolves, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.
+mana={1}{G}{G}
+type=Creature
+subtype=Beast Mutant
+power=3
+toughness=2
+[/card]
+[card]
+name=Scab-Clan Giant
+text=When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.
+mana={4}{R}{G}
+type=Creature
+subtype=Giant Warrior
+power=4
+toughness=5
+[/card]
+[card]
+name=Toil // Trouble
+text=Target player draws two cards and loses 2 life. --  //  -- Trouble deals damage to target player equal to the number of cards in that player's hand. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={2}{B} // {2}{R}
+type=Sorcery // Sorcery
+[/card]
+[card]
+name=Trait Doctoring
+text=Change the text of target permanent by replacing all instances of one color word with another or one basic land type with another until end of turn. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={U}
+type=Sorcery
+[/card]
+[card]
+name=Turn // Burn
+text=Target creature loses all abilities and becomes a 0/1 red Weird until end of turn. --  //  -- Burn deals 2 damage to target creature or player. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={2}{U} // {1}{R}
+type=Instant // Instant
+[/card]
+[card]
+name=Varolz, the Scar-Striped
+text=Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost. (Exile a creature card from your graveyard and pay its mana cost: Put a number of +1/+1 counters equal to that card's power on target creature. Scavenge only as a sorcery.) -- Sacrifice another creature: Regenerate Varolz, the Scar-Striped.
+mana={1}{B}{G}
+type=Legendary Creature
+subtype=Troll Warrior
+power=2
+toughness=2
+[/card]
+[card]
+name=Vorel of the Hull Clade
+text={G}{U}, {T}: For each counter on target artifact, creature, or land, put another of those counters on that permanent.
+mana={1}{G}{U}
+type=Legendary Creature
+subtype=Human Merfolk
+power=1
+toughness=4
+[/card]
+[card]
+name=Wear // Tear
+text=Destroy target artifact. --  //  -- Destroy target enchantment. --  -- Fuse (You may cast one or both halves of this card from your hand.)
+mana={1}{R} // {W}
+type=Instant // Instant
+[/card]

--- a/projects/mtg/bin/Res/missing_cards_by_sets/GTC.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/GTC.txt
@@ -1,0 +1,238 @@
+[card]
+name=Aurelia's Fury
+text=Aurelia's Fury deals X damage divided as you choose among any number of target creatures and/or players. Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.
+mana={X}{R}{W}
+type=Instant
+[/card]
+[card]
+name=Bane Alley Broker
+text={T}: Draw a card, then exile a card from your hand face down. -- You may look at cards exiled with Bane Alley Broker. -- {U}{B}, {T}: Return a card exiled with Bane Alley Broker to its owner's hand.
+mana={1}{U}{B}
+type=Creature
+subtype=Human Rogue
+power=0
+toughness=3
+[/card]
+[card]
+name=Bioshift
+text=Move any number of +1/+1 counters from target creature onto another target creature with the same controller.
+mana={GU}
+type=Instant
+[/card]
+[card]
+name=Call of the Nightwing
+text=Put a 1/1 blue and black Horror creature token with flying onto the battlefield. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={2}{U}{B}
+type=Sorcery
+[/card]
+[card]
+name=Clan Defiance
+text=Choose one or more — Clan Defiance deals X damage to target creature with flying; Clan Defiance deals X damage to target creature without flying; and/or Clan Defiance deals X damage to target player.
+mana={X}{R}{G}
+type=Sorcery
+[/card]
+[card]
+name=Dimir Charm
+text=Choose one — Counter target sorcery spell; or destroy target creature with power 2 or less; or look at the top three cards of target player's library, then put one back and the rest into that player's graveyard.
+mana={U}{B}
+type=Instant
+[/card]
+[card]
+name=Duskmantle Seer
+text=Flying -- At the beginning of your upkeep, each player reveals the top card of his or her library, loses life equal to that card's converted mana cost, then puts it into his or her hand.
+mana={2}{U}{B}
+type=Creature
+subtype=Vampire Wizard
+power=4
+toughness=4
+[/card]
+[card]
+name=Frontline Medic
+text=Battalion — Whenever Frontline Medic and at least two other creatures attack, creatures you control are indestructible this turn. -- Sacrifice Frontline Medic: Counter target spell with {X} in its mana cost unless its controller pays {3}.
+mana={2}{W}
+type=Creature
+subtype=Human Cleric
+power=3
+toughness=3
+[/card]
+[card]
+name=Guardian of the Gateless
+text=Flying -- Guardian of the Gateless can block any number of creatures. -- Whenever Guardian of the Gateless blocks, it gets +1/+1 until end of turn for each creature it's blocking.
+mana={4}{W}
+type=Creature
+subtype=Angel
+power=3
+toughness=3
+[/card]
+[card]
+name=Hands of Binding
+text=Tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={1}{U}
+type=Sorcery
+[/card]
+[card]
+name=Illusionist's Bracers
+text=Whenever an ability of equipped creature is activated, if it isn't a mana ability, copy that ability. You may choose new targets for the copy. -- Equip {3}
+mana={2}
+type=Artifact
+subtype=Equipment
+[/card]
+[card]
+name=Last Thoughts
+text=Draw a card. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={3}{U}
+type=Sorcery
+[/card]
+[card]
+name=Lazav, Dimir Mastermind
+text=Hexproof -- Whenever a creature card is put into an opponent's graveyard from anywhere, you may have Lazav, Dimir Mastermind become a copy of that card except its name is still Lazav, Dimir Mastermind, it's legendary in addition to its other types, and it gains hexproof and this ability.
+mana={U}{U}{B}{B}
+type=Legendary Creature
+subtype=Shapeshifter
+power=3
+toughness=3
+[/card]
+[card]
+name=Mark for Death
+text=Target creature an opponent controls blocks this turn if able. Untap that creature. Other creatures that player controls can't block this turn.
+mana={3}{R}
+type=Sorcery
+[/card]
+[card]
+name=Mental Vapors
+text=Target player discards a card. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={3}{B}
+type=Sorcery
+[/card]
+[card]
+name=Midnight Recovery
+text=Return target creature card from your graveyard to your hand. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={3}{B}
+type=Sorcery
+[/card]
+[card]
+name=Nightveil Specter
+text=Flying -- Whenever Nightveil Specter deals combat damage to a player, that player exiles the top card of his or her library. -- You may play cards exiled with Nightveil Specter.
+mana={UB}{UB}{UB}
+type=Creature
+subtype=Specter
+power=2
+toughness=3
+[/card]
+[card]
+name=Ooze Flux
+text={1}{G}, Remove one or more +1/+1 counters from among creatures you control: Put an X/X green Ooze creature token onto the battlefield, where X is the number of +1/+1 counters removed this way.
+mana={3}{G}
+type=Enchantment
+[/card]
+[card]
+name=Orzhov Charm
+text=Choose one — Return target creature you control and all Auras you control attached to it to their owner's hand; or destroy target creature and you lose life equal to its toughness; or return target creature card with converted mana cost 1 or less from your graveyard to the battlefield.
+mana={W}{B}
+type=Instant
+[/card]
+[card]
+name=Paranoid Delusions
+text=Target player puts the top three cards of his or her library into his or her graveyard. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={U}{B}
+type=Sorcery
+[/card]
+[card]
+name=Shadow Slice
+text=Target opponent loses 3 life. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={4}{B}
+type=Sorcery
+[/card]
+[card]
+name=Signal the Clans
+text=Search your library for three creature cards and reveal them. If you reveal three cards with different names, choose one of them at random and put that card into your hand. Shuffle the rest into your library.
+mana={R}{G}
+type=Instant
+[/card]
+[card]
+name=Simic Charm
+text=Choose one — Target creature gets +3/+3 until end of turn; or permanents you control gain hexproof until end of turn; or return target creature to its owner's hand.
+mana={G}{U}
+type=Instant
+[/card]
+[card]
+name=Simic Manipulator
+text=Evolve (Whenever a creature enters the battlefield under your control, if that creature has greater power or toughness than this creature, put a +1/+1 counter on this creature.) -- {T}, Remove one or more +1/+1 counters from Simic Manipulator: Gain control of target creature with power less than or equal to the number of +1/+1 counters removed this way.
+mana={1}{U}{U}
+type=Creature
+subtype=Mutant Wizard
+power=0
+toughness=1
+[/card]
+[card]
+name=Skullcrack
+text=Players can't gain life this turn. Damage can't be prevented this turn. Skullcrack deals 3 damage to target player.
+mana={1}{R}
+type=Instant
+[/card]
+[card]
+name=Soul Ransom
+text=Enchant creature -- You control enchanted creature. -- Discard two cards: Soul Ransom's controller sacrifices it, then draws two cards. Only any opponent may activate this ability.
+mana={2}{U}{B}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Stolen Identity
+text=Put a token onto the battlefield that's a copy of target artifact or creature. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={4}{U}{U}
+type=Sorcery
+[/card]
+[card]
+name=Structural Collapse
+text=Target player sacrifices an artifact and a land. Structural Collapse deals 2 damage to that player.
+mana={5}{R}
+type=Sorcery
+[/card]
+[card]
+name=Thespian's Stage
+text={T}: Add {1} to your mana pool. -- {2}, {T}: Thespian's Stage becomes a copy of target land and gains this ability.
+type=Land
+[/card]
+[card]
+name=Thrull Parasite
+text=Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.) -- {T}, Pay 2 life: Remove a counter from target nonland permanent.
+mana={B}
+type=Creature
+subtype=Thrull
+power=1
+toughness=1
+[/card]
+[card]
+name=Undercity Plague
+text=Target player loses 1 life, discards a card, then sacrifices a permanent. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={4}{B}{B}
+type=Sorcery
+[/card]
+[card]
+name=Unexpected Results
+text=Shuffle your library, then reveal the top card. If it's a nonland card, you may cast it without paying its mana cost. If it's a land card, you may put it onto the battlefield and return Unexpected Results to its owner's hand.
+mana={2}{G}{U}
+type=Sorcery
+[/card]
+[card]
+name=Vizkopa Confessor
+text=Extort (Whenever you cast a spell, you may pay {WB}. If you do, each opponent loses 1 life and you gain that much life.) -- When Vizkopa Confessor enters the battlefield, pay any amount of life. Target opponent reveals that many cards from his or her hand. You choose one of them and exile it.
+mana={3}{W}{B}
+type=Creature
+subtype=Human Cleric
+power=1
+toughness=3
+[/card]
+[card]
+name=Voidwalk
+text=Exile target creature. Return it to the battlefield under its owner's control at the beginning of the next end step. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={3}{U}
+type=Sorcery
+[/card]
+[card]
+name=Whispering Madness
+text=Each player discards his or her hand, then draws cards equal to the greatest number of cards a player discarded this way. -- Cipher (Then you may exile this spell card encoded on a creature you control. Whenever that creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost.)
+mana={2}{U}{B}
+type=Sorcery
+[/card]

--- a/projects/mtg/bin/Res/missing_cards_by_sets/RTR.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/RTR.txt
@@ -1,0 +1,127 @@
+[card]
+name=Conjured Currency
+text=At the beginning of your upkeep, you may exchange control of Conjured Currency and target permanent you neither own nor control.
+mana={5}{U}
+type=Enchantment
+[/card]
+[card]
+name=Corpsejack Menace
+text=If one or more +1/+1 counters would be placed on a creature you control, twice that many +1/+1 counters are placed on it instead.
+mana={2}{B}{G}
+type=Creature
+subtype=Fungus
+power=4
+toughness=4
+[/card]
+[card]
+name=Desecration Demon
+text=Flying -- At the beginning of each combat, any opponent may sacrifice a creature. If a player does, tap Desecration Demon and put a +1/+1 counter on it.
+mana={2}{B}{B}
+type=Creature
+subtype=Demon
+power=6
+toughness=6
+[/card]
+[card]
+name=Epic Experiment
+text=Exile the top X cards of your library. For each instant and sorcery card with converted mana cost X or less among them, you may cast that card without paying its mana cost. Then put all cards exiled this way that weren't cast into your graveyard.
+mana={X}{U}{R}
+type=Sorcery
+[/card]
+[card]
+name=Grave Betrayal
+text=Whenever a creature you don't control dies, return it to the battlefield under your control with an additional +1/+1 counter on it at the beginning of the next end step. That creature is a black Zombie in addition to its other colors and types.
+mana={5}{B}{B}
+type=Enchantment
+[/card]
+[card]
+name=Guild Feud
+text=At the beginning of your upkeep, target opponent reveals the top three cards of his or her library, may put a creature card from among them onto the battlefield, then puts the rest into his or her graveyard. You do the same with the top three cards of your library. If two creatures are put onto the battlefield this way, those creatures fight each other.
+mana={5}{R}
+type=Enchantment
+[/card]
+[card]
+name=Izzet Charm
+text=Choose one — Counter target noncreature spell unless its controller pays {2}; or Izzet Charm deals 2 damage to target creature; or draw two cards, then discard two cards.
+mana={U}{R}
+type=Instant
+[/card]
+[card]
+name=Jace, Architect of Thought
+text=+1: Until your next turn, whenever a creature an opponent controls attacks, it gets -1/-0 until end of turn. -- -2: Reveal the top three cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other on the bottom of your library in any order. -- -8: For each player, search that player's library for a nonland card and exile it, then that player shuffles his or her library. You may cast those cards without paying their mana costs.
+mana={2}{U}{U}
+type=Planeswalker
+subtype=Jace
+[/card]
+[card]
+name=Loxodon Smiter
+text=Loxodon Smiter can't be countered. -- If a spell or ability an opponent controls causes you to discard Loxodon Smiter, put it onto the battlefield instead of putting it into your graveyard.
+mana={1}{G}{W}
+type=Creature
+subtype=Elephant Soldier
+power=4
+toughness=4
+[/card]
+[card]
+name=Palisade Giant
+text=All damage that would be dealt to you or another permanent you control is dealt to Palisade Giant instead.
+mana={4}{W}{W}
+type=Creature
+subtype=Giant Soldier
+power=2
+toughness=7
+[/card]
+[card]
+name=Pithing Needle
+text=As Pithing Needle enters the battlefield, name a card. -- Activated abilities of sources with the chosen name can't be activated unless they're mana abilities.
+mana={1}
+type=Artifact
+[/card]
+[card]
+name=Rakdos, Lord of Riots
+text=You can't cast Rakdos, Lord of Riots unless an opponent lost life this turn. -- Flying, trample -- Creature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn.
+mana={B}{B}{R}{R}
+type=Legendary Creature
+subtype=Demon
+power=6
+toughness=6
+[/card]
+[card]
+name=Rites of Reaping
+text=Target creature gets +3/+3 until end of turn. Another target creature gets -3/-3 until end of turn.
+mana={4}{B}{G}
+type=Sorcery
+[/card]
+[card]
+name=Search the City
+text=When Search the City enters the battlefield, exile the top five cards of your library. -- Whenever you play a card with the same name as one of the exiled cards, you may put one of those cards with that name into its owner's hand. Then if there are no cards exiled with Search the City, sacrifice it. If you do, take an extra turn after this one.
+mana={4}{U}
+type=Enchantment
+[/card]
+[card]
+name=Slaughter Games
+text=Slaughter Games can't be countered by spells or abilities. -- Name a nonland card. Search target opponent's graveyard, hand, and library for any number of cards with that name and exile them. Then that player shuffles his or her library.
+mana={2}{B}{R}
+type=Sorcery
+[/card]
+[card]
+name=Sphere of Safety
+text=Creatures can't attack you or a planeswalker you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.
+mana={4}{W}
+type=Enchantment
+[/card]
+[card]
+name=Sphinx of the Chimes
+text=Flying -- Discard two nonland cards with the same name: Draw four cards.
+mana={4}{U}{U}
+type=Creature
+subtype=Sphinx
+power=5
+toughness=6
+[/card]
+[card]
+name=Tablet of the Guilds
+text=As Tablet of the Guilds enters the battlefield, choose two colors. -- Whenever you cast a spell, if it's at least one of the chosen colors, you gain 1 life for each of the chosen colors it is.
+mana={2}
+type=Artifact
+[/card]

--- a/projects/mtg/bin/Res/sets/primitives/borderline.txt
+++ b/projects/mtg/bin/Res/sets/primitives/borderline.txt
@@ -59,11 +59,11 @@ toughness=2
 [/card]
 [card]
 name=Conflux
-auto=ability$!moveto(myhand) notatarget(*[white]|mylibrary)!$ controller
-auto=ability$!moveto(myhand) notatarget(*[blue]|mylibrary)!$ controller
-auto=ability$!moveto(myhand) notatarget(*[black]|mylibrary)!$ controller
-auto=ability$!moveto(myhand) notatarget(*[red]|mylibrary)!$ controller
-auto=ability$!moveto(myhand) notatarget(*[green]|mylibrary)!$ controller
+auto=ability$!name(white card) moveto(myhand) notatarget(*[white]|mylibrary)!$ controller
+auto=ability$!name(blue card) moveto(myhand) notatarget(*[blue]|mylibrary)!$ controller
+auto=ability$!name(black card) moveto(myhand) notatarget(*[black]|mylibrary)!$ controller
+auto=ability$!name(red card) moveto(myhand) notatarget(*[red]|mylibrary)!$ controller
+auto=ability$!name(green card) moveto(myhand) notatarget(*[green]|mylibrary)!$ controller
 text=Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.
 mana={3}{W}{U}{B}{R}{G}
 type=Sorcery


### PR DESCRIPTION
halfup computation is correct but when used in negation, you must use
the halfdown counterpart. example if you have 5 life and you pay half your life
rounded up, you must have 3 life, so life:-halfdownlifetotal. if you use
halfup you will lose 3 life...