### PR TITLE
Add missing cards from THS

### DIFF
--- a/projects/mtg/bin/Res/missing_cards_by_sets/BNG.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/BNG.txt
@@ -1,0 +1,198 @@
+[card]
+name=Acolyte's Reward
+text=Prevent the next X damage that would be dealt to target creature this turn, where X is your devotion to white. If damage is prevented this way, Acolyte's Reward deals that much damage to target creature or player. (Each {W} in the mana costs of permanents you control counts toward your devotion to white.)
+mana={1}{W}
+type=Instant
+[/card]
+[card]
+name=Astral Cornucopia
+text=Astral Cornucopia enters the battlefield with X charge counters on it. -- {T}: Choose a color. Add one mana of that color to your mana pool for each charge counter on Astral Cornucopia.
+mana={X}{X}{X}
+type=Artifact
+[/card]
+[card]
+name=Brimaz, King of Oreskos
+text=Vigilance -- Whenever Brimaz, King of Oreskos attacks, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield attacking. -- Whenever Brimaz blocks a creature, put a 1/1 white Cat Soldier creature token with vigilance onto the battlefield blocking that creature.
+mana={1}{W}{W}
+type=Legendary Creature
+subtype=Cat Soldier
+power=3
+toughness=4
+[/card]
+[card]
+name=Champion of Stray Souls
+text={3}{B}{B}, {T}, Sacrifice X other creatures: Return X target creature cards from your graveyard to the battlefield. -- {5}{B}{B}: Put Champion of Stray Souls on top of your library from your graveyard.
+mana={4}{B}{B}
+type=Creature
+subtype=Skeleton Warrior
+power=4
+toughness=4
+[/card]
+[card]
+name=Courser of Kruphix
+text=Play with the top card of your library revealed. -- You may play the top card of your library if it's a land card. -- Whenever a land enters the battlefield under your control, you gain 1 life.
+mana={1}{G}{G}
+type=Enchantment Creature
+subtype=Centaur
+power=2
+toughness=4
+[/card]
+[card]
+name=Dawn to Dusk
+text=Choose one or both — Return target enchantment card from your graveyard to your hand; and/or destroy target enchantment.
+mana={2}{W}{W}
+type=Sorcery
+[/card]
+[card]
+name=Flame-Wreathed Phoenix
+text=Flying -- Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.) -- When Flame-Wreathed Phoenix enters the battlefield, if tribute wasn't paid, it gains haste and "When this creature dies, return it to its owner's hand."
+mana={2}{R}{R}
+type=Creature
+subtype=Phoenix
+power=3
+toughness=3
+[/card]
+[card]
+name=Hero of Leina Tower
+text=Heroic — Whenever you cast a spell that targets Hero of Leina Tower, you may pay {X}. If you do, put X +1/+1 counters on Hero of Leina Tower.
+mana={G}
+type=Creature
+subtype=Human Warrior
+power=1
+toughness=1
+[/card]
+[card]
+name=Heroes' Podium
+text=Each legendary creature you control gets +1/+1 for each other legendary creature you control. -- {X}, {T}: Look at the top X cards of your library. You may reveal a legendary creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+mana={5}
+type=Legendary Artifact
+[/card]
+[card]
+name=Kraken of the Straits
+text=Creatures with power less than the number of Islands you control can't block Kraken of the Straits.
+mana={5}{U}{U}
+type=Creature
+subtype=Kraken
+power=6
+toughness=6
+[/card]
+[card]
+name=Mindreaver
+text=Heroic — Whenever you cast a spell that targets Mindreaver, exile the top three cards of target player's library. -- {U}{U}, Sacrifice Mindreaver: Counter target spell with the same name as a card exiled with Mindreaver.
+mana={U}{U}
+type=Creature
+subtype=Human Wizard
+power=2
+toughness=1
+[/card]
+[card]
+name=Mogis, God of Slaughter
+text=Indestructible -- As long as your devotion to black and red is less than seven, Mogis isn't a creature. -- At the beginning of each opponent's upkeep, Mogis deals 2 damage to that player unless he or she sacrifices a creature.
+mana={2}{B}{R}
+type=Legendary Enchantment Creature
+subtype=God
+power=7
+toughness=5
+[/card]
+[card]
+name=Nessian Demolok
+text=Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.) -- When Nessian Demolok enters the battlefield, if tribute wasn't paid, destroy target noncreature permanent.
+mana={3}{G}{G}
+type=Creature
+subtype=Beast
+power=3
+toughness=3
+[/card]
+[card]
+name=Nessian Wilds Ravager
+text=Tribute 6 (As this creature enters the battlefield, an opponent of your choice may place six +1/+1 counters on it.) -- When Nessian Wilds Ravager enters the battlefield, if tribute wasn't paid, you may have Nessian Wilds Ravager fight another target creature. (Each deals damage equal to its power to the other.)
+mana={4}{G}{G}
+type=Creature
+subtype=Hydra
+power=6
+toughness=6
+[/card]
+[card]
+name=Oracle of Bones
+text=Haste -- Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.) -- When Oracle of Bones enters the battlefield, if tribute wasn't paid, you may cast an instant or sorcery card from your hand without paying its mana cost.
+mana={2}{R}{R}
+type=Creature
+subtype=Minotaur Shaman
+power=3
+toughness=1
+[/card]
+[card]
+name=Peregrination
+text=Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle your library, then scry 1. (Look at the top card of your library. You may put that card on the bottom of your library.)
+mana={3}{G}
+type=Sorcery
+[/card]
+[card]
+name=Perplexing Chimera
+text=Whenever an opponent casts a spell, you may exchange control of Perplexing Chimera and that spell. If you do, you may choose new targets for the spell. (If the spell becomes a permanent, you control that permanent.)
+mana={4}{U}
+type=Enchantment Creature
+subtype=Chimera
+power=3
+toughness=3
+[/card]
+[card]
+name=Pharagax Giant
+text=Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.) -- When Pharagax Giant enters the battlefield, if tribute wasn't paid, Pharagax Giant deals 5 damage to each opponent.
+mana={4}{R}
+type=Creature
+subtype=Giant
+power=3
+toughness=3
+[/card]
+[card]
+name=Shrike Harpy
+text=Flying -- Tribute 2 (As this creature enters the battlefield, an opponent of your choice may place two +1/+1 counters on it.) -- When Shrike Harpy enters the battlefield, if tribute wasn't paid, target opponent sacrifices a creature.
+mana={3}{B}{B}
+type=Creature
+subtype=Harpy
+power=2
+toughness=2
+[/card]
+[card]
+name=Siren of the Fanged Coast
+text=Flying -- Tribute 3 (As this creature enters the battlefield, an opponent of your choice may place three +1/+1 counters on it.) -- When Siren of the Fanged Coast enters the battlefield, if tribute wasn't paid, gain control of target creature.
+mana={3}{U}{U}
+type=Creature
+subtype=Siren
+power=1
+toughness=1
+[/card]
+[card]
+name=Spirit of the Labyrinth
+text=Each player can't draw more than one card each turn.
+mana={1}{W}
+type=Enchantment Creature
+subtype=Spirit
+power=3
+toughness=1
+[/card]
+[card]
+name=Tromokratis
+text=Tromokratis has hexproof unless it's attacking or blocking. -- Tromokratis can't be blocked unless all creatures defending player controls block it. (If any creature that player controls doesn't block this creature, it can't be blocked.)
+mana={5}{U}{U}
+type=Legendary Creature
+subtype=Kraken
+power=8
+toughness=8
+[/card]
+[card]
+name=Vortex Elemental
+text={U}: Put Vortex Elemental and each creature blocking or blocked by it on top of their owners' libraries, then those players shuffle their libraries. -- {3}{U}{U}: Target creature blocks Vortex Elemental this turn if able.
+mana={U}
+type=Creature
+subtype=Elemental
+power=0
+toughness=1
+[/card]
+[card]
+name=Whims of the Fates
+text=Starting with you, each player separates all permanents he or she controls into three piles. Then each player chooses one of his or her piles at random and sacrifices those permanents. (Piles can be empty.)
+mana={5}{R}
+type=Sorcery
+[/card]

--- a/projects/mtg/bin/Res/missing_cards_by_sets/JOU.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/JOU.txt
@@ -1,0 +1,264 @@
+[card]
+name=Aerial Formation
+text=Strive — Aerial Formation costs {2}{U} more to cast for each target beyond the first. -- Any number of target creatures each get +1/+1 and gain flying until end of turn.
+mana={U}
+type=Instant
+[/card]
+[card]
+name=Ajani's Presence
+text=Strive — Ajani's Presence costs {2}{W} more to cast for each target beyond the first. -- Any number of target creatures each get +1/+1 and gain indestructible until end of turn. (Damage and effects that say "destroy" don't destroy them.)
+mana={W}
+type=Instant
+[/card]
+[card]
+name=Ajani, Mentor of Heroes
+text=+1: Distribute three +1/+1 counters among one, two, or three target creatures you control. -- +1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card from among them and put it into your hand. Put the rest on the bottom of your library in any order. -- -8: You gain 100 life.
+mana={3}{G}{W}
+type=Planeswalker
+subtype=Ajani
+[/card]
+[card]
+name=Athreos, God of Passage
+text=Indestructible -- As long as your devotion to white and black is less than seven, Athreos isn't a creature. -- Whenever another creature you own dies, return it to your hand unless target opponent pays 3 life.
+mana={1}{W}{B}
+type=Legendary Enchantment Creature
+subtype=God
+power=5
+toughness=4
+[/card]
+[card]
+name=Battlefield Thaumaturge
+text=Each instant and sorcery spell you cast costs {1} less to cast for each creature it targets. -- Heroic — Whenever you cast a spell that targets Battlefield Thaumaturge, Battlefield Thaumaturge gains hexproof until end of turn.
+mana={1}{U}
+type=Creature
+subtype=Human Wizard
+power=2
+toughness=1
+[/card]
+[card]
+name=Blinding Flare
+text=Strive — Blinding Flare costs {R} more to cast for each target beyond the first. -- Any number of target creatures can't block this turn.
+mana={R}
+type=Sorcery
+[/card]
+[card]
+name=Colossal Heroics
+text=Strive — Colossal Heroics costs {1}{G} more to cast for each target beyond the first. -- Any number of target creatures each get +2/+2 until end of turn. Untap those creatures.
+mana={2}{G}
+type=Instant
+[/card]
+[card]
+name=Consign to Dust
+text=Strive — Consign to Dust costs {2}{G} more to cast for each target beyond the first. -- Destroy any number of target artifacts and/or enchantments.
+mana={2}{G}
+type=Instant
+[/card]
+[card]
+name=Cruel Feeding
+text=Strive — Cruel Feeding costs {2}{B} more to cast for each target beyond the first. -- Any number of target creatures each get +1/+0 and gain lifelink until end of turn. (Damage dealt by a creature with lifelink also causes its controller to gain that much life.)
+mana={B}
+type=Instant
+[/card]
+[card]
+name=Dakra Mystic
+text={U}, {T}: Each player reveals the top card of his or her library. You may put the revealed cards into their owners' graveyards. If you don't, each player draws a card.
+mana={U}
+type=Creature
+subtype=Merfolk Wizard
+power=1
+toughness=1
+[/card]
+[card]
+name=Daring Thief
+text=Inspired — Whenever Daring Thief becomes untapped, you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it.
+mana={2}{U}
+type=Creature
+subtype=Human Rogue
+power=2
+toughness=3
+[/card]
+[card]
+name=Desperate Stand
+text=Strive — Desperate Stand costs {R}{W} more to cast for each target beyond the first. -- Any number of target creatures each get +2/+0 and gain first strike and vigilance until end of turn.
+mana={R}{W}
+type=Sorcery
+[/card]
+[card]
+name=Dictate of the Twin Gods
+text=Flash -- If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.
+mana={3}{R}{R}
+type=Enchantment
+[/card]
+[card]
+name=Disciple of Deceit
+text=Inspired — Whenever Disciple of Deceit becomes untapped, you may discard a nonland card. If you do, search your library for a card with the same converted mana cost as that card, reveal it, put it into your hand, then shuffle your library.
+mana={U}{B}
+type=Creature
+subtype=Human Rogue
+power=1
+toughness=3
+[/card]
+[card]
+name=Godsend
+text=Equipped creature gets +3/+3. -- Whenever equipped creature blocks or becomes blocked by one or more creatures, you may exile one of those creatures. -- Opponents can't cast cards with the same name as cards exiled with Godsend. -- Equip {3}
+mana={1}{W}{W}
+type=Legendary Artifact
+subtype=Equipment
+[/card]
+[card]
+name=Goldenhide Ox
+text=Constellation — Whenever Goldenhide Ox or another enchantment enters the battlefield under your control, target creature must be blocked this turn if able.
+mana={5}{G}
+type=Enchantment Creature
+subtype=Ox
+power=5
+toughness=4
+[/card]
+[card]
+name=Harness by Force
+text=Strive — Harness by Force costs {2}{R} more to cast for each target beyond the first. -- Gain control of any number of target creatures until end of turn. Untap those creatures. They gain haste until end of turn.
+mana={1}{R}{R}
+type=Sorcery
+[/card]
+[card]
+name=Hour of Need
+text=Strive — Hour of Need costs {1}{U} more to cast for each target beyond the first. -- Exile any number of target creatures. For each creature exiled this way, its controller puts a 4/4 blue Sphinx creature token with flying onto the battlefield.
+mana={2}{U}
+type=Instant
+[/card]
+[card]
+name=Keranos, God of Storms
+text=Indestructible -- As long as your devotion to blue and red is less than seven, Keranos isn't a creature. -- Reveal the first card you draw on each of your turns. Whenever you reveal a land card this way, draw a card. Whenever you reveal a nonland card this way, Keranos deals 3 damage to target creature or player.
+mana={3}{U}{R}
+type=Legendary Enchantment Creature
+subtype=God
+power=6
+toughness=5
+[/card]
+[card]
+name=Kiora's Dismissal
+text=Strive — Kiora's Dismissal costs {U} more to cast for each target beyond the first. -- Return any number of target enchantments to their owners' hands.
+mana={U}
+type=Instant
+[/card]
+[card]
+name=Knowledge and Power
+text=Whenever you scry, you may pay {2}. If you do, Knowledge and Power deals 2 damage to target creature or player.
+mana={4}{R}
+type=Enchantment
+[/card]
+[card]
+name=Kruphix, God of Horizons
+text=Indestructible -- As long as your devotion to green and blue is less than seven, Kruphix isn't a creature. -- You have no maximum hand size. -- If unused mana would empty from your mana pool, that mana becomes colorless instead.
+mana={3}{G}{U}
+type=Legendary Enchantment Creature
+subtype=God
+power=4
+toughness=7
+[/card]
+[card]
+name=Launch the Fleet
+text=Strive — Launch the Fleet costs {1} more to cast for each target beyond the first. -- Until end of turn, any number of target creatures each gain "Whenever this creature attacks, put a 1/1 white Soldier creature token onto the battlefield tapped and attacking."
+mana={W}
+type=Sorcery
+[/card]
+[card]
+name=Nature's Panoply
+text=Strive — Nature's Panoply costs {2}{G} more to cast for each target beyond the first. -- Choose any number of target creatures. Put a +1/+1 counter on each of them.
+mana={G}
+type=Instant
+[/card]
+[card]
+name=Oppressive Rays
+text=Enchant creature -- Enchanted creature can't attack or block unless its controller pays {3}. -- Activated abilities of enchanted creature cost {3} more to activate.
+mana={W}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Phalanx Formation
+text=Strive — Phalanx Formation costs {1}{W} more to cast for each target beyond the first. -- Any number of target creatures each gain double strike until end of turn. (They deal both first-strike and regular combat damage.)
+mana={2}{W}
+type=Instant
+[/card]
+[card]
+name=Polymorphous Rush
+text=Strive — Polymorphous Rush costs {1}{U} more to cast for each target beyond the first. -- Choose a creature on the battlefield. Any number of target creatures you control each become a copy of that creature until end of turn.
+mana={2}{U}
+type=Instant
+[/card]
+[card]
+name=Pull from the Deep
+text=Return up to one target instant card and up to one target sorcery card from your graveyard to your hand. Exile Pull from the Deep.
+mana={2}{U}{U}
+type=Sorcery
+[/card]
+[card]
+name=Quarry Colossus
+text=When Quarry Colossus enters the battlefield, put target creature into its owner's library just beneath the top X cards of that library, where X is the number of Plains you control.
+mana={5}{W}{W}
+type=Creature
+subtype=Giant
+power=5
+toughness=6
+[/card]
+[card]
+name=Ritual of the Returned
+text=Exile target creature card from your graveyard. Put a black Zombie creature token onto the battlefield. Its power is equal to that card's power and its toughness is equal to that card's toughness.
+mana={3}{B}
+type=Instant
+[/card]
+[card]
+name=Rouse the Mob
+text=Strive — Rouse the Mob costs {2}{R} more to cast for each target beyond the first. -- Any number of target creatures each get +2/+0 and gain trample until end of turn.
+mana={R}
+type=Instant
+[/card]
+[card]
+name=Sage of Hours
+text=Heroic — Whenever you cast a spell that targets Sage of Hours, put a +1/+1 counter on it. -- Remove all +1/+1 counters from Sage of Hours: For each five counters removed this way, take an extra turn after this one.
+mana={1}{U}
+type=Creature
+subtype=Human Wizard
+power=1
+toughness=1
+[/card]
+[card]
+name=Setessan Tactics
+text=Strive — Setessan Tactics costs {G} more to cast for each target beyond the first. -- Until end of turn, any number of target creatures each get +1/+1 and gain "{T}: This creature fights another target creature."
+mana={1}{G}
+type=Instant
+[/card]
+[card]
+name=Silence the Believers
+text=Strive — Silence the Believers costs {2}{B} more to cast for each target beyond the first. -- Exile any number of target creatures and all Auras attached to them.
+mana={2}{B}{B}
+type=Instant
+[/card]
+[card]
+name=Solidarity of Heroes
+text=Strive — Solidarity of Heroes costs {1}{G} more to cast for each target beyond the first. -- Choose any number of target creatures. Double the number of +1/+1 counters on each of them.
+mana={1}{G}
+type=Instant
+[/card]
+[card]
+name=Stonewise Fortifier
+text={4}{W}: Prevent all damage that would be dealt to Stonewise Fortifier by target creature this turn.
+mana={1}{W}
+type=Creature
+subtype=Human Wizard
+power=2
+toughness=2
+[/card]
+[card]
+name=Twinflame
+text=Strive — Twinflame costs {2}{R} more to cast for each target beyond the first. -- Choose any number of target creatures you control. For each of them, put a token that's a copy of that creature onto the battlefield. Those tokens have haste. Exile them at the beginning of the next end step.
+mana={1}{R}
+type=Sorcery
+[/card]
+[card]
+name=Worst Fears
+text=You control target player during that player's next turn. Exile Worst Fears. (You see all cards that player could see and make all decisions for the player.)
+mana={7}{B}
+type=Sorcery
+[/card]

--- a/projects/mtg/bin/Res/missing_cards_by_sets/THS.txt
+++ b/projects/mtg/bin/Res/missing_cards_by_sets/THS.txt
@@ -1,0 +1,192 @@
+[card]
+name=Artisan of Forms
+text=Heroic — Whenever you cast a spell that targets Artisan of Forms, you may have Artisan of Forms become a copy of target creature and gain this ability.
+mana={1}{U}
+type=Creature
+subtype=Human Wizard
+power=1
+toughness=1
+[/card]
+[card]
+name=Ashiok, Nightmare Weaver
+text=+2: Exile the top three cards of target opponent's library. -- -X: Put a creature card with converted mana cost X exiled with Ashiok, Nightmare Weaver onto the battlefield under your control. That creature is a Nightmare in addition to its other types. -- -10: Exile all cards from all opponents' hands and graveyards.
+mana={1}{U}{B}
+type=Planeswalker
+subtype=Ashiok
+[/card]
+[card]
+name=Coastline Chimera
+text=Flying -- {1}{W}: Coastline Chimera can block an additional creature this turn.
+mana={3}{U}
+type=Creature
+subtype=Chimera
+power=1
+toughness=5
+[/card]
+[card]
+name=Daxos of Meletis
+text=Daxos of Meletis can't be blocked by creatures with power 3 or greater. -- Whenever Daxos of Meletis deals combat damage to a player, exile the top card of that player's library. You gain life equal to that card's converted mana cost. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it.
+mana={1}{W}{U}
+type=Legendary Creature
+subtype=Human Soldier
+power=2
+toughness=2
+[/card]
+[card]
+name=Decorated Griffin
+text=Flying -- {1}{W}: Prevent the next 1 combat damage that would be dealt to you this turn.
+mana={4}{W}
+type=Creature
+subtype=Griffin
+power=2
+toughness=3
+[/card]
+[card]
+name=Flamespeaker Adept
+text=Whenever you scry, Flamespeaker Adept gets +2/+0 and gains first strike until end of turn.
+mana={2}{R}
+type=Creature
+subtype=Human Shaman
+power=2
+toughness=3
+[/card]
+[card]
+name=Hundred-Handed One
+text=Vigilance -- {3}{W}{W}{W}: Monstrosity 3. (If this creature isn't monstrous, put three +1/+1 counters on it and it becomes monstrous.) -- As long as Hundred-Handed One is monstrous, it has reach and can block an additional ninety-nine creatures each combat.
+mana={2}{W}{W}
+type=Creature
+subtype=Giant
+power=3
+toughness=5
+[/card]
+[card]
+name=Loathsome Catoblepas
+text={2}{G}: Loathsome Catoblepas must be blocked this turn if able. -- When Loathsome Catoblepas dies, target creature an opponent controls gets -3/-3 until end of turn.
+mana={5}{B}
+type=Creature
+subtype=Beast
+power=3
+toughness=3
+[/card]
+[card]
+name=Medomai the Ageless
+text=Flying -- Whenever Medomai the Ageless deals combat damage to a player, take an extra turn after this one. -- Medomai the Ageless can't attack during extra turns.
+mana={4}{W}{U}
+type=Legendary Creature
+subtype=Sphinx
+power=4
+toughness=4
+[/card]
+[card]
+name=Meletis Charlatan
+text={2}{U}, {T}: The controller of target instant or sorcery spell copies it. That player may choose new targets for the copy.
+mana={2}{U}
+type=Creature
+subtype=Human Wizard
+power=2
+toughness=3
+[/card]
+[card]
+name=Nemesis of Mortals
+text=Nemesis of Mortals costs {1} less to cast for each creature card in your graveyard. -- {7}{G}{G}: Monstrosity 5. This ability costs {1} less to activate for each creature card in your graveyard. (If this creature isn't monstrous, put five +1/+1 counters on it and it becomes monstrous.)
+mana={4}{G}{G}
+type=Creature
+subtype=Snake
+power=5
+toughness=5
+[/card]
+[card]
+name=Ordeal of Erebos
+text=Enchant creature -- Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Erebos. -- When you sacrifice Ordeal of Erebos, target player discards two cards.
+mana={1}{B}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Ordeal of Heliod
+text=Enchant creature -- Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Heliod. -- When you sacrifice Ordeal of Heliod, you gain 10 life.
+mana={1}{W}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Ordeal of Nylea
+text=Enchant creature -- Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Nylea. -- When you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.
+mana={1}{G}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Ordeal of Purphoros
+text=Enchant creature -- Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Purphoros. -- When you sacrifice Ordeal of Purphoros, it deals 3 damage to target creature or player.
+mana={1}{R}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Ordeal of Thassa
+text=Enchant creature -- Whenever enchanted creature attacks, put a +1/+1 counter on it. Then if it has three or more +1/+1 counters on it, sacrifice Ordeal of Thassa. -- When you sacrifice Ordeal of Thassa, draw two cards.
+mana={1}{U}
+type=Enchantment
+subtype=Aura
+[/card]
+[card]
+name=Polukranos, World Eater
+text={X}{X}{G}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.) -- When Polukranos, World Eater becomes monstrous, it deals X damage divided as you choose among any number of target creatures your opponents control. Each of those creatures deals damage equal to its power to Polukranos.
+mana={2}{G}{G}
+type=Legendary Creature
+subtype=Hydra
+power=5
+toughness=5
+[/card]
+[card]
+name=Psychic Intrusion
+text=Target opponent reveals his or her hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.
+mana={3}{U}{B}
+type=Sorcery
+[/card]
+[card]
+name=Pyxis of Pandemonium
+text={T}: Each player exiles the top card of his or her library face down. -- {7}, {T}, Sacrifice Pyxis of Pandemonium: Each player turns face up all cards he or she owns exiled with Pyxis of Pandemonium, then puts all permanent cards among them onto the battlefield.
+mana={1}
+type=Artifact
+[/card]
+[card]
+name=Rescue from the Underworld
+text=As an additional cost to cast Rescue from the Underworld, sacrifice a creature. -- Choose target creature card in your graveyard. Return that card and the sacrificed card to the battlefield under your control at the beginning of your next upkeep. Exile Rescue from the Underworld.
+mana={4}{B}
+type=Instant
+[/card]
+[card]
+name=Satyr Piper
+text={3}{G}: Target creature must be blocked this turn if able.
+mana={2}{G}
+type=Creature
+subtype=Satyr Rogue
+power=2
+toughness=1
+[/card]
+[card]
+name=Shipbreaker Kraken
+text={6}{U}{U}: Monstrosity 4. (If this creature isn't monstrous, put four +1/+1 counters on it and it becomes monstrous.) -- When Shipbreaker Kraken becomes monstrous, tap up to four target creatures. Those creatures don't untap during their controllers' untap steps for as long as you control Shipbreaker Kraken.
+mana={4}{U}{U}
+type=Creature
+subtype=Kraken
+power=6
+toughness=6
+[/card]
+[card]
+name=Steam Augury
+text=Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard.
+mana={2}{U}{R}
+type=Instant
+[/card]
+[card]
+name=Underworld Cerberus
+text=Underworld Cerberus can't be blocked except by three or more creatures. -- Cards in graveyards can't be the targets of spells or abilities. -- When Underworld Cerberus dies, exile it and each player returns all creature cards from his or her graveyard to his or her hand.
+mana={3}{B}{R}
+type=Creature
+subtype=Hound
+power=6
+toughness=6
+[/card]


### PR DESCRIPTION
also fix heroic and gods (gods are legendary enchantment creature in all zones, it changes only to non creature if it's in play and it didn't met the condition..."	The type-changing ability that can make the God not be a creature functions only on the battlefield. It’s always a creature card in other zones, regardless of your devotion to its color")