### PR TITLE
Refactor PW Rule & some bug fixes

### DIFF
--- a/projects/mtg/include/MTGRules.h
+++ b/projects/mtg/include/MTGRules.h
@@ -427,7 +427,7 @@ public:
  * that player chooses one of them, and the rest are put into their owners’ graveyards. 
  * This is called the “legend rule.” 
  */
-class MTGLegendRule: public PermanentAbility
+class MTGLegendRule: public ListMaintainerAbility
 {
 public:
     TargetChooser * tcL;
@@ -435,7 +435,10 @@ public:
     MTGAbility * LegendruleAbility;
     MTGAbility * LegendruleGeneric;
     MTGLegendRule(GameObserver* observer, int _id);
-    int receiveEvent(WEvent * event);
+    int canBeInList(MTGCardInstance * card);
+    int added(MTGCardInstance * card);
+    int removed(MTGCardInstance * card);
+    int testDestroy();
     virtual ostream& toString(ostream& out) const;
     virtual MTGLegendRule * clone() const;
 };

--- a/projects/mtg/include/MTGRules.h
+++ b/projects/mtg/include/MTGRules.h
@@ -445,6 +445,10 @@ public:
 class MTGPlaneWalkerRule: public ListMaintainerAbility
 {
 public:
+    TargetChooser * tcP;
+    MTGAbility * PWrule;
+    MTGAbility * PWruleAbility;
+    MTGAbility * PWruleGeneric;
     MTGPlaneWalkerRule(GameObserver* observer, int _id);
     int canBeInList(MTGCardInstance * card);
     int added(MTGCardInstance * card);

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -3347,6 +3347,7 @@ InstantAbility(observer, id, card, _target),flipStats(flipStats),isflipcard(isfl
 int AAFlip::resolve()
 {
     int cdaDamage = 0;
+    int activatedanyability = 0;
     MTGCardInstance * Flipper = (MTGCardInstance*)source;
     this->oneShot = true;
     if(Flipper->isFlipped)
@@ -3397,6 +3398,17 @@ int AAFlip::resolve()
                 _target->setMTGId(myFlip->getMTGId());
                 _target->setId = myFlip->setId;
             }
+            //check pw
+            if(_target->hasType(Subtypes::TYPE_PLANESWALKER))
+            {
+                for(unsigned int k = 0;k < _target->cardsAbilities.size();++k)
+                {
+                    ActivatedAbility * check = dynamic_cast<ActivatedAbility*>(_target->cardsAbilities[k]);
+                    if(check && check->counters)
+                        activatedanyability++;
+                }
+            }
+            //
             for(unsigned int i = 0;i < _target->cardsAbilities.size();i++)
             {
                 MTGAbility * a = dynamic_cast<MTGAbility *>(_target->cardsAbilities[i]);
@@ -3425,6 +3437,19 @@ int AAFlip::resolve()
                         {
                             _target->cardsAbilities.push_back(a);
                         }
+                    }
+                }
+            }
+            //limit pw abi
+            if(activatedanyability)
+            {
+                if(_target->hasType(Subtypes::TYPE_PLANESWALKER))
+                {
+                    for(unsigned int k = 0;k < _target->cardsAbilities.size();++k)
+                    {
+                        ActivatedAbility * check = dynamic_cast<ActivatedAbility*>(_target->cardsAbilities[k]);
+                        if(check)//is there a better way?
+                            check->counters++;
                     }
                 }
             }


### PR DESCRIPTION
PermanentAbility to ListMaintainerAbility in Legend Rule, it seems It's finally fixed even with a lot of targetchooser and copy effects. Also fixes the window for the triggered sacrifice and legend rule with Thespian's Stage copying Dark Depths.
Fixed where planeswalker can use its ability after it was transformed/flipped by activation ex. Garruk Relentless... You can’t activate a loyalty ability of Garruk Relentless and later that turn after he transforms activate a loyalty ability of Garruk, the Veil-Cursed.

