### PR TITLE
Refactor countManaProducedby

### DIFF
--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -1125,14 +1125,30 @@ public:
     int countManaProducedby(int color, MTGCardInstance * target, Player * player)
     {
         int count = 0;
-        for (size_t i = 0; i < target->getObserver()->mLayers->actionLayer()->manaObjects.size(); i++)
+        GameObserver * observer = player->getObserver();
+        MTGGameZone * zone = player->game->battlefield;
+        for(int k = 0; k < zone->nb_cards; k++)
+        {
+            MTGCardInstance * card = zone->cards[k];
+            if(card->isLand() && (card != target) && card->hasSubtype("forest") && color == 1)
+                count++;
+            if(card->isLand() && (card != target) && card->hasSubtype("island") && color == 2)
+                count++;
+            if(card->isLand() && (card != target) && card->hasSubtype("mountain") && color == 3)
+                count++;
+            if(card->isLand() && (card != target) && card->hasSubtype("swamp") && color == 4)
+                count++;
+            if(card->isLand() && (card != target) && card->hasSubtype("plains") && color == 5)
+                count++;
+            if(card->isLand() && (card != target) && card->cardsAbilities.size())
             {
-                if (dynamic_cast<AManaProducer*> (((MTGAbility *) target->getObserver()->mLayers->actionLayer()->manaObjects[i])) && 
-                    (dynamic_cast<AManaProducer*> (((MTGAbility *) target->getObserver()->mLayers->actionLayer()->manaObjects[i])))->source->isLand() && 
-                    (dynamic_cast<AManaProducer*> (((MTGAbility *) target->getObserver()->mLayers->actionLayer()->manaObjects[i])))->source->controller() == player && 
-                    (dynamic_cast<AManaProducer*> (((MTGAbility *) target->getObserver()->mLayers->actionLayer()->manaObjects[i])))->output->hasColor(color))
-                    count += 1;
+                for(unsigned int j = 0; j < card->cardsAbilities.size(); j++)
+                {
+                    if(dynamic_cast<AManaProducer*> (card->cardsAbilities[j]) && dynamic_cast<AManaProducer*> (card->cardsAbilities[j])->output->hasColor(color) )
+                        count++;
+                }
             }
+        }
         return count;
     }
 

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -1125,7 +1125,6 @@ public:
     int countManaProducedby(int color, MTGCardInstance * target, Player * player)
     {
         int count = 0;
-        GameObserver * observer = player->getObserver();
         MTGGameZone * zone = player->game->battlefield;
         for(int k = 0; k < zone->nb_cards; k++)
         {

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -3760,21 +3760,6 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
         bool doesntEmptyTilueot = s.find("doesntempty") != string::npos;
         ManaCost * output = ManaCost::parseManaCost(s.substr(found),NULL,card);
         Targetable * t = spell ? spell->getNextTarget() : NULL;
-        if(output->getConvertedCost() > 0)
-        {
-            if(output->hasColor(Constants::MTG_COLOR_ARTIFACT)||output->hasColor(Constants::MTG_COLOR_WASTE))
-                card->canproduceC = 1;
-            if(output->hasColor(Constants::MTG_COLOR_GREEN))
-                card->canproduceG = 1;
-            if(output->hasColor(Constants::MTG_COLOR_BLUE))
-                card->canproduceU = 1;
-            if(output->hasColor(Constants::MTG_COLOR_RED))
-                card->canproduceR = 1;
-            if(output->hasColor(Constants::MTG_COLOR_BLACK))
-                card->canproduceB = 1;
-            if(output->hasColor(Constants::MTG_COLOR_WHITE))
-                card->canproduceW = 1;
-        }
         MTGAbility * a = NEW AManaProducer(observer, id, card, t, output, NULL, who,s.substr(found),doesntEmptyTilueot);
         a->oneShot = 1;
         if(newName.size())


### PR DESCRIPTION
Cards that uses this (Reflecting Pool, Harvester Druid etc...) should not crash anymore with lorded mana producer from instants like Rain of Filth...