### PR TITLE
Fix Aura/Equipment on Illegal Objects

### DIFF
--- a/projects/mtg/src/CardGui.cpp
+++ b/projects/mtg/src/CardGui.cpp
@@ -113,7 +113,7 @@ void CardGui::Update(float dt)
 
 void CardGui::DrawCard(const Pos& inPosition, int inMode, bool thumb, bool noborder, bool gdv)
 {
-    DrawCard(card, inPosition, inMode, thumb, noborder);
+    DrawCard(card, inPosition, inMode, thumb, noborder, gdv);
 }
 
 void CardGui::DrawCard(MTGCard* inCard, const Pos& inPosition, int inMode, bool thumb, bool noborder, bool gdv)


### PR DESCRIPTION
704.5n If an Aura is attached to an illegal object or player, or is not
attached to an object or player, that Aura is put into its owner’s
graveyard.

704.5p If an Equipment or Fortification is attached to an illegal
permanent, it becomes unattached from that permanent. It remains on the
battlefield.

704.5q If a creature is attached to an object or player, it becomes
unattached and remains on the battlefield. Similarly, if a permanent
that’s neither an Aura, an Equipment, nor a Fortification is attached to
an object or player, it becomes unattached and remains on the
battlefield.