### PR TITLE
Etched Affinity stalling the game

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck110.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck110.txt
@@ -1,7 +1,6 @@
 #NAME:Etched Affinity
 #DESC:Modern URB Aggro
 #HINT:dontattackwith(creature[power<=0])
-#HINT:combo hold(Glimmervoid|myhand)^cast(Glimmervoid|myhand)^restriction{type(land[fresh]|mybattlefield)~lessthan~1,type(artifact|mybattlefield)~morethan~0}^totalmananeeded({0})
 #HINT:combo hold(Galvanic Blast|myhand)^cast(Galvanic Blast|myhand)^restriction{type(artifact|mybattlefield)~morethan~2,turn:3}^totalmananeeded({R})
 
 #25 creatures

--- a/projects/mtg/src/AIPlayerBaka.cpp
+++ b/projects/mtg/src/AIPlayerBaka.cpp
@@ -2542,6 +2542,10 @@ MTGCardInstance * AIPlayerBaka::FindCardToPlay(ManaCost * pMana, const char * ty
 
         if (card->hasType(Subtypes::TYPE_LEGENDARY) && game->inPlay->findByName(card->name))
             continue;
+        //glimmervoid alias to avoid ai stalling the game as the hint combo is stuck
+        //next card to play was galvanic blast but on activate combo it clashes with glimmervoid...
+        if ((card->alias == 48132) && (card->controller()->game->inPlay->countByType("artifact") < 1))
+            continue;
 
         if (card->has(Constants::TREASON) && observer->getCurrentGamePhase() != MTG_PHASE_FIRSTMAIN)
             continue;
@@ -2693,6 +2697,10 @@ MTGCardInstance * AIPlayerBaka::FindCardToPlay(ManaCost * pMana, const char * ty
 
         if (card->hasType(Subtypes::TYPE_LEGENDARY) && game->inPlay->findByName(card->name))
             continue;
+        //glimmervoid alias to avoid ai stalling the game as the hint combo is stuck
+        //next card to play was galvanic blast but on activate combo it clashes with glimmervoid...
+        if ((card->alias == 48132) && (card->controller()->game->inPlay->countByType("artifact") < 1))
+            continue;
 
         if (card->has(Constants::TREASON) && observer->getCurrentGamePhase() != MTG_PHASE_FIRSTMAIN)
             continue;
@@ -2842,6 +2850,10 @@ MTGCardInstance * AIPlayerBaka::FindCardToPlay(ManaCost * pMana, const char * ty
         }
 
         if (card->hasType(Subtypes::TYPE_LEGENDARY) && game->inPlay->findByName(card->name))
+            continue;
+        //glimmervoid alias to avoid ai stalling the game as the hint combo is stuck
+        //next card to play was galvanic blast but on activate combo it clashes with glimmervoid...
+        if ((card->alias == 48132) && (card->controller()->game->inPlay->countByType("artifact") < 1))
             continue;
 
         if (card->has(Constants::TREASON) && observer->getCurrentGamePhase() != MTG_PHASE_FIRSTMAIN)


### PR DESCRIPTION
add an alias for glimmervoid and removed the hold combo hint for glimmervoid, just tried etched affinity vs etched affinity on demo for 50 games... it doesn't stall anymore. it seems there's a conflict somewhere parsing hint combo? not really sure... also in momir the ai don't click choose a color command, noticed on lotus cobra so i changed the chooseacolor to ability$! add{mana} ...