### PR TITLE
Some fixes

### DIFF
--- a/projects/mtg/src/ActionStack.cpp
+++ b/projects/mtg/src/ActionStack.cpp
@@ -711,7 +711,8 @@ int ActionStack::addAbility(MTGAbility * ability)
     if (!observer->players[0]->isAI() && ability->source->controller() == observer->players[0] && 0
         == options[Options::INTERRUPTMYABILITIES].number)
     {
-        if(observer->gameType() == GAME_TYPE_MOMIR && ability->aType == MTGAbility::FORCED_TOKEN_CREATOR)
+        if((observer->gameType() == GAME_TYPE_MOMIR && ability->aType == MTGAbility::FORCED_TOKEN_CREATOR)||
+            (dynamic_cast<GenericTargetAbility *>(ability) && ability->canBeInterrupted && !observer->OpenedDisplay && !observer->players[0]->game->reveal->cards.size()))//test interrupt...
             interruptDecision[0] = NOT_DECIDED;
         else
             interruptDecision[0] = DONT_INTERRUPT;

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -7733,11 +7733,14 @@ void ABlink::resolveBlink()
             this->forceDestroy = 1;
             return;
         }
-
         if (_target && _target->next)
             _target = _target->next;
         _target->blinked = true;
         Blinked = _target;
+        if(source->isPermanent()&&!source->isInPlay(game))
+        {
+            Blinked->blinked = false;
+        }
         if (!blinkueot && !blinkForSource)
         {
             returnCardIntoPlay(_target);

--- a/projects/mtg/src/CardGui.cpp
+++ b/projects/mtg/src/CardGui.cpp
@@ -461,12 +461,16 @@ void CardGui::Render()
     }
 
     string buff = "";
+    string starMark = "";
+    if(card->exerted)
+        starMark += "*";
     if(card->isToken && !card->isACopier)
         buff = "T";
     if(card->isToken && card->isACopier)
         buff = "CT";
     if(!card->isToken && card->isACopier)
         buff = "C";
+    buff = starMark + buff;
     //if(card->has(Constants::PAYZERO))
         //buff += "Z";
     if(card->chooseacolor >= 1)

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -576,6 +576,20 @@ int AbilityFactory::parseCastRestrictions(MTGCardInstance * card, Player * playe
                 return 0;
         }
 
+        check = restriction[i].find("hasexerted");
+        if(check != string::npos)
+        {
+            if(!card->exerted)
+                return 0;
+        }
+
+        check = restriction[i].find("notexerted");
+        if(check != string::npos)
+        {
+            if(card->exerted)
+                return 0;
+        }
+
         check = restriction[i].find("discardbyopponent");
         if(check != string::npos)
         {


### PR DESCRIPTION
Interrupt Target abilities - We must have this since cards that grant negative/positive effects on permanents can be interrupted... (If its resolving then it must not be interrupted, only when declared as target...)

Fix Blink - If somehow the card source is permanent is removed from play before the blink effect, the target is exiled permanently.. example card: Oblivion Ring is removed while ETB, since it has two triggers, except cards like Banishing Light which has single trigger(So cards with similar wording _"until"_ like Banishing Light needs recode not to use (blink)forsrc maybe (blinkuntil) key? )...

Add indicator for exerted cards - uses "*" as indicator...