### PR TITLE
Add check for NULL this pointer in is_open

### DIFF
--- a/JGE/src/zipFS/zstream.h
+++ b/JGE/src/zipFS/zstream.h
@@ -70,7 +70,7 @@ public:
 	virtual zbuffer * open(const char * Filename, std::streamoff Offset, std::streamoff Size) = 0;
 	virtual zbuffer * close() = 0;
 
-	bool is_open() const	{ return m_Opened; }
+	bool is_open() const	{ return this != NULL && m_Opened; }
     bool is_used() const {return m_Used;}
     void unuse() { m_Used = false;}
     bool use(std::streamoff Offset, std::streamoff Size);


### PR DESCRIPTION
I was getting crashes on windows, so I ran it under the VS 2010 debugger, and I got an Unhandled Exception in `zstream.h`'s `is_open` method. The debugger said the `this` pointer was `NULL`, so I added a check for that, returning false if that is the case.

![Screenshot 2021-03-06 114651](https://user-images.githubusercontent.com/2133026/110217886-e7c94c00-7e73-11eb-94a3-3405f4ded418.png)
