### PR TITLE
Upgrade AI decks 7, 9, 10 to modern frames

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck10.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck10.txt
@@ -7,75 +7,24 @@
 # (would've been better to add creatures, but all creatures in the
 # deck were already at 4 pieces))
 
-#Spark Elemental
-129577
-129577
-129577
-129577
-#Raging Goblin
-129688
-129688
-129688
-129688
-#Goblin Piker
-129580
-129580
-129580
-129580
-#Goblin King
-129578
-129578
-129578
-129578
-#Goblin Striker
-48592
-48592
-48592
-48592
-#Lightning Bolt
-1303
-1303
-1303
-1303
-#Wheel of Fate
-1326
-#Black Vise
-1097
-1097
-1097
-1097
-#Hearthfire Hobgoblin
-157201
-157201
-157201
-157201
-#Howling Mine
-129598
-129598
-129598
-#Goblin Mountaineer
-174938
-174938
-174938
-174938
-#Mountain
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
-1390
+# Land(s)
+Mountain (8ED) * 20
+
+# Creature(s)
+Goblin King (8ED) * 4
+Goblin Mountaineer (9ED) * 4
+Goblin Piker (9ED) * 4
+Goblin Striker (MRD) * 4
+Hearthfire Hobgoblin (EVE) * 4
+Raging Goblin (8ED) * 4
+Spark Elemental (5DN) * 4
+
+# Artifact(s)
+Black Vise (V10) * 4
+Howling Mine (8ED) * 3
+
+# Instant(s)
+Lightning Bolt (M10) * 4
+
+# Sorcery(s)
+Wheel of Fortune (VMA) * 1

--- a/projects/mtg/bin/Res/ai/baka/deck7.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck7.txt
@@ -2,76 +2,24 @@
 #DESC:O miserable of happy 
 #DESC:Is this the end
 #DESC:Of this new glorious world 
-#3x Wrath of God
-129808
-129808
-129808
-#4x Savannah Lions
-1365
-1365
-1365
-1365
-#4x Sigiled Paladin {W}{W}, first strike exalted 2/2
-174958
-174958
-174958
-174958
-#4x Serra Angel
-129726
-129726
-129726
-129726
-#4 x Guardian of Akrasa {2}{W} - defender 0/4 exalted
-175103
-175103
-175103
-175103
-#3x Skyhunter Skirmisher {1}{W}{W} - flying double strike, 1/1
-129513
-129513
-129513
-#1x Paladin en-Vec {1}{W}{W} - 2/2
-129668
-#4x Crusade
-1341
-1341
-1341
-1341
-#4x Sword to plowshares
-1367
-1367
-1367
-1367
-#4x White Knight
-1370
-1370
-1370
-1370
-#4x Armageddon
-1328
-1328
-1328
-1328
-# Plains (RV)
-1395
-1395
-1395
-1395
-1396
-1396
-1396
-1397
-1397
-1397
-# Plains (10E)
-175030
-175030
-175030
-175030
-175030
-175030
-175030
-175030
-175030
-175030
-175030
+# Land(s)
+Plains (8ED) * 21
+
+# Creature(s)
+Guardians of Akrasa (ALA) * 4
+Paladin en-Vec (9ED) * 1
+Savannah Lions (8ED) * 4
+Serra Angel (8ED) * 4
+Sigiled Paladin (ALA) * 4
+Skyhunter Skirmisher (5DN) * 3
+White Knight (M10) * 4
+
+# Enchantment(s)
+Crusade (DDF) * 4
+
+# Instant(s)
+Swords to Plowshares (DDF) * 4
+
+# Sorcery(s)
+Armageddon (VMA) * 4
+Wrath of God (8ED) * 3

--- a/projects/mtg/bin/Res/ai/baka/deck9.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck9.txt
@@ -2,76 +2,21 @@
 #DESC:See all your efforts shattered
 #DESC:by the all-consuming power
 #DESC:of righteous fury.
-#2x Shatter
-1316
-1316
-#2xDisenchant
-1343
-1343
-#4x Anaba BodyGuard
-134753
-134753
-134753
-134753
-#4xAncestor's chosen
-130550
-130550
-130550
-130550
-#4xAngelic Wall
-129671
-129671
-129671
-129671
-#4xThundering Giant
-130381
-130381
-130381
-130381
-#2x Tempest of Light
-132131
-132131
-#2x Suntail Hawk
-129753
-129753
-#4x Steadfast Guard
-132111
-132111
-132111
-132111
-#4xRock Badger
-129715
-129715
-129715
-129715
-#4x lightning bolt
-1303
-1303
-1303
-1303
-#12plains
-129680
-129681
-129682
-129683
-129680
-129681
-129682
-129683
-129680
-129681
-129682
-129683
-#12mountains
-129649
-129650
-129651
-129652
-129649
-129650
-129651
-129652
-129649
-129650
-129651
-129652
+# Land(s)
+Mountain (8ED) * 12
+Plains (8ED) * 12
+
+# Creature(s)
+Anaba Bodyguard (10E) * 4
+Ancestor's Chosen (10E) * 4
+Angelic Wall (10E) * 4
+Rock Badger (10E) * 4
+Steadfast Guard (10E) * 4
+Suntail Hawk (8ED) * 2
+Thundering Giant (10E) * 4
+
+# Instant(s)
+Disenchant (M20) * 2
+Lightning Bolt (M10) * 4
+Shatter (8ED) * 2
+Tempest of Light (MRD) * 2


### PR DESCRIPTION
Hello, I've noticed that AI decks are written using mixed syntax:
```
baka/deck1.txt:
1129

baka/deck24.txt:
Rhox Pikemaster *4

baka/deck25.txt:
Druid of the Anima (ALA) *2 
```
I would like to provide later some help with fixing game bugs. I don't understand the code yet, so started with formatting AI decks in clean way (no changes in decklists, just change the syntax). What do you think about it? 

If you like it, I can work on more decks. 