### PR TITLE
Upgrade AI decks 3, 30-36, 38 to modern frames

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck3.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck3.txt
@@ -4,94 +4,36 @@
 #DESC:there is no time for dispute
 #DESC:or rivalries
 #DESC:in Eladamri and Gerrard's army
-#2x Black Vise
-1097
-1097
-#2x The Rack
-1139
-1139
-#2x Cockatrice
-1238
-1238
-#2x Craw Wurm
-1239
-1239
-#2x Giant Spider
-1249
-1249
-#2x Grizzly Bears
-1250
-1250
-#2x Ironroot Treefolk
-1253
-1253
-#1x Living Lands 
-1259
-#3x Scryb Sprites
-1264
-1264
-1264
-#4x Shanodin Dryads
-1265
-1265
-1265
-1265
-#2x Thicket Basilisk
-1267
-1267
-#1x War Mammoth 
-1277
-#1x Armageddon
-1328
 # (PSY) 2x Benalish Hero not available any more, removed (deck has still >60 cards)
-#2x Benalish Hero
-#1330
-#1330
-#2x Castle
-1334
-1334
-#2x Crusade
-1341
-1341
 # (PSY) 2x Mesa Pegasus not available any more, removed (deck has still >60 cards)
-#2x Mesa Pegasus
-#1354
-#1354
-#2x Pearled Unicorn
-1356
-1356
-#2x Savannah Lions
-1365
-1365
-#2x Serra Angel
-1366
-1366
-#2x Wrath of God
-1372
-1372
-# Forest (RV)
-1386
-1386
-1386
-1386
-1387
-1387
-1387
-1387
-1388
-1388
-1388
-1388
-# Plains (RV)
-1395
-1395
-1395
-1395
-1396
-1396
-1396
-1396
-1397
-1397
-1397
-1397
+
+# Land(s)
+Forest (8ED) * 13
+Plains (8ED) * 9
+
+# Creature(s)
+Cockatrice (TSB) * 2
+Craw Wurm (9ED) * 2
+Giant Spider (AKH) * 2
+Grizzly Bears (8ED) * 2
+Spitting Spider (8ED) * 2
+Ronom Unicorn (CSP) * 2
+Savannah Lions (A25) * 2
+Scute Mob (ZEN) * 3
+Serra Angel (M13) * 2
+Jukai Messenger (CHK) * 4
+Kessig Recluse (DKA) * 2
+Rhox Charger (ALA) * 1
+
+# Artifact(s)
+Black Vise (V10) * 2
+The Rack (DPA) * 2
+
+# Enchantment(s)
+Builder's Blessing (AVR) * 2
+Crusade (DDF) * 2
+Living Lands (ME4) * 1
+
+# Sorcery(s)
+Armageddon (VMA) * 1
+Wrath of God (8ED) * 2

--- a/projects/mtg/bin/Res/ai/baka/deck30.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck30.txt
@@ -9,21 +9,23 @@
 #DESC:
 #DESC:You have no chance!
 
-Llanowar Elves (M10) *4
-Wellwisher (ONS) *4
-Elvish Vanguard (ONS) *4
-Elvish Visionary (M10) *4
-Elvish Hexhunter (SHM) *4
-Elvish Promenade (LRW) *4
-Elvish Archdruid (M10) *4
-Imperious Perfect (LRW) *4
-Drove of Elves (SHM) *1
-Heedless One (ONS) *3
-Overrun (10E) *2
-Forest (10E) *4
-Forest (M10) *4
-Forest (ALA) *4
-Forest (LRW) *4
-Forest (RAV) *4
-Pendelhaven (LEG) *1
-Gaea's Cradle (USG) *1
+# Land(s)
+Forest (M12) * 20
+Gaea's Cradle (PRM) * 1
+Pendelhaven (A25) * 1
+
+# Creature(s)
+Drove of Elves (SHM) * 1
+Elvish Archdruid (M10) * 4
+Elvish Hexhunter (SHM) * 4
+Elvish Vanguard (EMA) * 4
+Elvish Visionary (ALA) * 4
+Heedless One (PSAL) * 3
+Imperious Perfect (LRW) * 4
+Llanowar Elves (9ED) * 4
+Wellwisher (C14) * 4
+
+# Sorcery(s)
+Elvish Promenade (LRW) * 4
+Overrun (10E) * 2
+

--- a/projects/mtg/bin/Res/ai/baka/deck31.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck31.txt
@@ -3,20 +3,26 @@
 #DESC:will sweep through your defenses
 #DESC:while all your forces can do
 #DESC:is watch and gape in awe.
-Angelic Chorus (10E) *3
-Honor of the Pure (M10) *4
-Kitchen Finks (SHM) *4
-Mesa Enchantress (M10) *4
-Moat (LEG) *3
-Pacifism (10E) *4
-Cage of Hands (CHK) *3
-Sigil of the Empty Throne (CFX) *4
-Swords to Plowshares (ICE) *4
-Wrath of God (10E) *3
-Quicksand (10E) *4
-Plains (10E) *4
-Plains (M10) *4
-Plains (ALA) *4
-Plains (LRW) *4
-Plains (RAV) *3
-Serra's Sanctum (USG) *1
+# Land(s)
+Plains (M15) * 19
+Quicksand (WWK) * 4
+Serra's Sanctum (*) * 1
+
+# Creature(s)
+Kitchen Finks (SHM) * 4
+Mesa Enchantress (PLC) * 4
+
+# Enchantment(s)
+Angelic Chorus (10E) * 3
+Cage of Hands (CHK) * 3
+Honor of the Pure (M10) * 4
+Moat (PRM) * 3
+Pacifism (A25) * 4
+Sigil of the Empty Throne (CFX) * 4
+
+# Instant(s)
+Swords to Plowshares (DDF) * 4
+
+# Sorcery(s)
+Wrath of God (10E) * 3
+

--- a/projects/mtg/bin/Res/ai/baka/deck32.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck32.txt
@@ -3,20 +3,24 @@
 #DESC:and barely present,
 #DESC:but if you let them grow
 #DESC:they will crush your army.
-Crusade (RV) *4
-Glorious Anthem (10E) *4
-Honor of the Pure (M10) *4
-Armored Ascension (M10) *2
-Swords to Plowshares (ICE) *4
-Disenchant (TMP) *3
-Paladin en-Vec (10E) *2
-Knight of Meadowgrain (LRW) *4
-Kitchen Finks (SHM) *3
-Spectral Procession (SHM) *4
-Stillmoon Cavalier (EVE) *3
-Plains (10E) *4
-Plains (M10) *4
-Plains (ALA) *4
-Plains (LRW) *4
-Plains (SHM) *4
-Plains (RAV) *3
+# Land(s)
+Plains (M21) * 23
+
+# Creature(s)
+Kitchen Finks (SHM) * 3
+Knight of Meadowgrain (LRW) * 4
+Paladin en-Vec (10E) * 2
+Stillmoon Cavalier (EVE) * 3
+
+# Enchantment(s)
+Armored Ascension (SHM) * 2
+Crusade (DDF) * 4
+Glorious Anthem (8ED) * 4
+Honor of the Pure (M10) * 4
+
+# Instant(s)
+Disenchant (TPR) * 3
+Swords to Plowshares (DDF) * 4
+
+# Sorcery(s)
+Spectral Procession (SHM) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck33.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck33.txt
@@ -4,19 +4,24 @@
 #DESC: And we will grow stronger
 #DESC: as you keep losing
 #DESC: your thoughts."
-The Rack (RV) *4
-Doom Blade (M10) *4
-Last Gasp (RAV) *4
-Hymn to Tourach (FEM) *4
-Black Knight (M10) *4
-Hypnotic Specter (10E) *4
-Nyxathid (CFX) *4
-Graveborn Muse (10E) *4
-Tendrils of Corruption (M10) *4   
-Gargoyle Castle (M10) *4
-Volrath's Stronghold (STH) *1
-Swamp (10E) *4
-Swamp (M10) *4
-Swamp (ALA) *4
-Swamp (LRW) *4
-Swamp (RAV) *3
+# Land(s)
+Gargoyle Castle (M10) * 4
+Swamp (M21) * 19
+Volrath's Stronghold (TPR) * 1
+
+# Creature(s)
+Black Knight (M10) * 4
+Graveborn Muse (10E) * 4
+Hypnotic Specter (M10) * 4
+Nyxathid (CFX) * 4
+
+# Artifact(s)
+The Rack (DPA) * 4
+
+# Instant(s)
+Doom Blade (M10) * 4
+Last Gasp (RAV) * 4
+Tendrils of Corruption (TSP) * 4
+
+# Sorcery(s)
+Hymn to Tourach (V13) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck34.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck34.txt
@@ -1,49 +1,55 @@
 #NAME:Kobold Overlord
-#
 #DESC:"You may think we are weak
 #DESC: But we are many
 #DESC: And sometimes we can hire
 #DESC: A powerful mercenary!"
-#
-Mountain (10E)              *20
-Kher Keep (TSP)             *2 # produces kobold tokens
-Crimson Kobolds (LEG)       *4
-Crookshank Kobolds (LEG)    *4
-Kobold Drill Sergeant (LEG) *4
-Kobold Overlord (LEG)       *4
-Kobold Taskmaster (LEG)     *4
-Kobolds of Kher Keep (LEG)  *4
-Battle Squadron (MRQ)       *2 # to have a flyer in the deck
-Keldon Warlord (RV)         *2
-#   Doesn't fit the theme too well (would a Keldon Warlord really
-#   work as a mercenary for a Kobold Overlord?), but without it
-#   the deck would be too weak, and a deck full of weak
-#   creatures is exactly the environment where a Keldon Warlord
-#   thrives.
-Wheel of Fortune (RV)       *1
-#To get a new hand (hopefully) full of cheap kobolds once the
-#previous hand has been used up. Only 1 because it's
-#restricted.
-Slate of Ancestry (ONS)     *2
-#To draw more cards (check whether the AI overuses it and
-#decks itself out)
-Howling Mine (10E)          *4
-Mob Justice (STH)           *3  # finisher
-#
-#
+
 # Cards considered, but not included:
 # Orcish Oriflamme - would match the deck's focus of
 #   strengthening the creatures, but is too expensive. Perhaps add
 #   it when mana acceleration is possible for this deck.
-#
+
 # Cards removed from he deck:
 # 3 x Bravado (USG) (ID 5848)
 # The card's name and illustration don't really fit the "kobold"
 # theme, but the effect (strength through numbers) definitely
 # does.
 # Removed because the AI casts it on its opponent's creatures.
-#
+
 # 4 x Brightstone Ritual (ONS) (ID 39846)
 # for mana acceleration
 # Removed because the AI doesn't use the mana.
 # Also ... only works with goblins. Duh. *blush*
+
+# Land(s)
+Kher Keep (TSP) * 2 # produces kobold tokens
+Mountain (ONS) * 20 
+
+# Creature(s)
+Battle Squadron (MMQ) * 2
+Crimson Kobolds (ME3) * 4
+Crookshank Kobolds (ME1) * 4
+Keldon Warlord (5ED) * 2
+#   Doesn't fit the theme too well (would a Keldon Warlord really
+#   work as a mercenary for a Kobold Overlord?), but without it
+#   the deck would be too weak, and a deck full of weak
+#   creatures is exactly the environment where a Keldon Warlord
+#   thrives.
+
+Kobold Drill Sergeant (ME3) * 4
+Kobold Overlord (ME3) * 4
+Kobold Taskmaster (ME3) * 4
+Kobolds of Kher Keep (ME3) * 4
+
+# Artifact(s)
+Howling Mine (7ED) * 4
+Slate of Ancestry (ONS) * 2
+#To draw more cards (check whether the AI overuses it and
+#decks itself out)
+
+# Sorcery(s)
+Mob Justice (*) * 3
+Wheel of Fortune (VMA) * 1
+#To get a new hand (hopefully) full of cheap kobolds once the
+#previous hand has been used up. Only 1 because it's
+#restricted.

--- a/projects/mtg/bin/Res/ai/baka/deck35.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck35.txt
@@ -8,54 +8,30 @@
 #DESC:into a squirming mass
 #DESC:of these small, yet dangerous
 #DESC:... things ...
-#
-#
 
-Winged Sliver (TMP)  *2 # gives Flying
+# Land(s)
+Forest (8ED) * 12
+Island (8ED) * 3
+Mountain (8ED) * 6
+Plains (8ED) * 3
 
-Horned Sliver (TMP)  *3 # gives Trample, also 2/2 isn't bad for a
-#                       # 3-drop creature that others will pump 
+# Creature(s)
+Bonesplitter Sliver (TSP) * 4 # nice cumulative +2/+0 bonus
+Crystalline Sliver (H09) * 1  # Shroud is nice, especially in a deck with no non-creature spells
+Fury Sliver (TSP) * 2         # gives double strike, only 2 because it's a 6-drop creature
+Gemhide Sliver (TSP) * 4      # Additional mana source to get Might Slivers out faster
+Heart Sliver (H09) * 2        # gives Haste
+Horned Sliver (TPR) * 3       # gives Trample, also 2/2 isn't bad for a 3-drop creature that others will pump
+Might Sliver (TSP) * 4        # nice cumulative +2/+2 bonus
+Muscle Sliver (H09) * 4       # cheap and the +1/+1 bonus is cumulative and can't be misused by the AI
+Shadow Sliver (TSP) * 1       # might be great or bad - thrown in as an element of surprise
+Spined Sliver (H09) * 2       # gives Rampage
+Spinneret Sliver (TSP) * 3    # 2/2 Sliver for only 2 mana, also gives Reach to all slivers, which is good because we only have
+#                             # two Winged Slivers in the deck, and those might not even be played because we have few Islands.
+Talon Sliver (*) * 3          # gives First Strike
+Watcher Sliver (TSP) * 1      # nice cumulative +0/+2 bonus, but too expensive to have more of them, and we have 3 plains in the deck
+Winged Sliver (H09) * 2       # gives Flying
 
-Muscle Sliver (TMP)  *4 # cheap and the +1/+1 bonus is cumulative
-#                       # and can't be misused by the AI
-
-Heart Sliver (TMP)   *2 # gives Haste
-
-Talon Sliver (TMP)   *3 # gives First Strike
-
-Watcher Sliver (TSP) *1 # nice cumulative +0/+2 bonus, but too
-#                       # expensive to have more of them, and we
-#                       # only have 3 plains in the deck
-
-Shadow Sliver (TSP) *1  # might be great or bad - thrown in as
-#                       # an element of surprise
-
-Crystalline Sliver (STH) *1 # Shroud is nice, especially in a
-#                           # deck with no non-creature spells
-
-Bonesplitter Sliver (TSP) *4  # nice cumulative +2/+0 bonus
-
-Fury Sliver (TSP) *2    # gives double strike, only 2 because
-#                       # it's a 6-drop creature
-
-Might Sliver (TSP) *4   # nice cumulative +2/+2 bonus
-#
-Spined Sliver (STH) *2  # gives Rampage
-
-Spinneret Sliver (TSP) *3  # 2/2 Sliver for only 2 mana, also
-# gives Reach to all slivers, which is good because we only have
-# two Winged Slivers in the deck, and those might not even be
-# played because we have few Islands.
-
-Gemhide Sliver (TSP) *4 # Additional mana source to get Might
-#                       # Slivers out faster
-
-Forest (M10)   *12      # (most slivers in the deck are green)
-Island (M10)   *3       # only 4 blue creatures in the deck
-Mountain (M10) *6
-Plains (M10)   *3       # only 5 white creatures in the deck
-
-#
 # Cards considered, but not included:
 # Basal Sliver - AI too eager to sacrifice
 # Clot Sliver - would be the only black sliver left after Basal

--- a/projects/mtg/bin/Res/ai/baka/deck36.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck36.txt
@@ -1,53 +1,7 @@
 #NAME:Master of Ether
-#
 #DESC:"Surrounded by the things I built
 #DESC: my power will grow
 #DESC: boundlessly."
-#
-
-Master of Etherium (ALA) *4  # gets stronger with every artifact
-
-Vedalken Archmage (MRD)  *2  # draws card when summoning artifact
-
-Ornithopter (10E)        *4  # cheap artifact, later air defense
-Nuisance Engine (MRD)    *4  # create more cheap artifacts
-
-Cathodion (MRD)          *4  # 3-drop 3/3 creature without a down-
-#                            # side since manaburn was abolished
-
-Steel Wall (MRD)         *2  # mainly for defending
-Yotian Soldier (MRD)     *2  # cheap defender
-
-Coiled Tinviper (TMP)    *1  # first strike attacker
-
-Scarecrone (EVE)         *2  # brings back artifacts
-
-Glaze Fiend (ALA)        *2  # temp. bonus for playing artifacts
-
-Salvage Slasher (CFX)    *2  # grows stronger with artifacts in
-#                            # graveyard - nice effect if opponent
-#                            # has destroyed all artifacts
-
-Silver Myr (MRD)         *4  # artifact source of blue mana (which
-#                            # is needed for the 6 Vedalken)
-
-Akroma's Memorial (FUT)  *2  # massive bonuses incl. Trample
-
-
-Island (10E)             *3  # more blue mana
-
-Seat of the Synod (MRD)  *4  # 20 artifact lands for huge bonuses
-Vault of Whispers (MRD)  *4  # on Master of Etherium and Tolarian
-Great Furnace (MRD)      *4  # Academy.
-Tree of Tales (MRD)      *4
-Ancient Den (MRD)        *4
-
-Academy Ruins (TSP)      *1  # brings back artifacts
-
-Tolarian Academy (USG)   *1  # Generates massive amounts of mana
-#                            # in this deck - which the AI usually
-#                            # wastes.
-
 
 # Cards considered, but not included:
 # Gaea's Cradle - would make the deck even stronger, but doesn't
@@ -55,3 +9,30 @@ Tolarian Academy (USG)   *1  # Generates massive amounts of mana
 #
 # Cards removed from the deck:
 # Sculpting Steel - reported to lead to crashes
+
+# Land(s)
+Ancient Den (MRD) * 4        # 20 artifact lands for huge bonuses on Master of Etherium and Tolarian Academy.
+Great Furnace (MRD) * 4
+Seat of the Synod (MRD) * 4
+Tree of Tales (MRD) * 4
+Vault of Whispers (MRD) * 4
+Academy Ruins (TSP) * 1      # brings back artifacts
+Tolarian Academy (VMA) * 1   # Generates massive amounts of mana in this deck - which the AI usually wastes.
+Island (10E) * 3
+
+# Creature(s)
+Cathodion (C14) * 4          # 3-drop 3/3 creature without a down-side since manaburn was abolished
+Coiled Tinviper (TPR) * 1    # first strike attacker
+Glaze Fiend (ALA) * 2        # temp. bonus for playing artifacts
+Master of Etherium (ALA) * 4 # gets stronger with every artifact
+Ornithopter (MRD) * 4        # cheap artifact, later air defense
+Salvage Slasher (CFX) * 2    # grows stronger with artifacts in graveyard - nice effect if opponent has destroyed all artifacts
+Scarecrone (EVE) * 2         # brings back artifacts
+Silver Myr (MRD) * 4         # artifact source of blue mana (which is needed for the 6 Vedalken)
+Steel Wall (MRD) * 2         # mainly for defending
+Vedalken Archmage (MRD) * 2  # draws card when summoning artifact
+Yotian Soldier (MRD) * 2     # cheap defender
+
+# Artifact(s)
+Akroma's Memorial (FUT) * 2  # massive bonuses incl. Trample
+Nuisance Engine (MRD) * 4    # create more cheap artifacts

--- a/projects/mtg/bin/Res/ai/baka/deck38.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck38.txt
@@ -2,20 +2,25 @@
 #DESC:If you ever thought
 #DESC:  that YOU had bad dreams ...
 #DESC:Wait until you meet these.
-Black Vise (RV) *1
-Wheel of Fortune (RV) *1
-Howling Mine (M10) *4
-Underworld Dreams (10E) *4
-Spiteful Visions (SHM) *4
-Sudden Impact (10E) *4
-Font of Mythos (CFX) *2
-Damnation (PLC) *4
-Infest (ALA) *4
-Lightning Bolt (M10) *4
-Terminate (ARB) *4
-Swamp (RAV) *4
-Swamp (TSP) *4
-Swamp (LRW) *4
-Swamp (ALA) *4
-Mountain (RAV) *4
-Mountain (TSP) *4
+# Land(s)
+Mountain (M10) * 8
+Swamp (M10) * 16
+
+# Artifact(s)
+Black Vise (V10) * 1
+Font of Mythos (CFX) * 2
+Howling Mine (8ED) * 4
+
+# Enchantment(s)
+Spiteful Visions (SHM) * 4
+Underworld Dreams (8ED) * 4
+
+# Instant(s)
+Lightning Bolt (M10) * 4
+Sudden Impact (8ED) * 4
+Terminate (ARB) * 4
+
+# Sorcery(s)
+Damnation (PLC) * 4
+Infest (ALA) * 4
+Wheel of Fortune (VMA) * 1


### PR DESCRIPTION
Initially committed in 89dae6523 (Nov 3, 2008) and 202d46176 (Sep 22, 2009).

Major changes done only in deck3:
- Castle -> Builder's Blessing (functional reprint)
- Ironroot Treefolk (vanilla 3/5) -> Spitting Spider (reach, 3/5)
- Thicket Basilisk (deathtouch 2/4) -> Kessig Recluse (reach, deathtouch 2/3)
- Pearled Unicorn (cmc 3, 2/2) -> Ronom Unicorn (cmc 2, 2/2)
- Scryb Sprites (flying 1/1) -> Scute Mob (1/1, +4/+4 with 5 lands)
- Shanodin Dryads -> Jukai Messenger (functional reprint)
- War Mammoth (trample 3/3) -> Rhox Charger (trample, exalted 3/3)

Also deck34 (Kobolds) was kept with original frames because Kobolds were never reprinted.