### PR TITLE
New AI commander deck for intermediate players

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck18.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck18.txt
@@ -1,60 +1,60 @@
-#Plain white deck
-#NAME:Justice
-#DESC:Defending law with an army
-#DESC:of zealous followers,
-#DESC:every criminal shall be punished
-#DESC:with the wrath of the just.
-#4x Crusade,{W}{W}, Enchantment, all white creatures +1/+1
-1341
-1341
-1341
-1341
-#4x Swords to Plowshares, {W} Remove target creature from game, controller gains life = strength
-1367
-1367
-1367
-1367
+#NAME:Kithkin
+#DESC:Led by the Cenn,
+#DESC:united by the thoughtweft,
+#DESC:challenge just one 
+#DESC:champion of Goldmeadow,
+#DESC:and you will face 
+#DESC:the entire cla-chan!
 #4x Glorious Anthem, {1}{W}{W}, Enchantment, Creatures you control get +1/+1
 129572
 129572
 129572
 129572
-#4x Paladin en-Vec, {1}{W}{W}, Creature - Human Knight,2/2, first strike protection from red and black
-129668
-129668
-129668
-129668
-#4x Knight of Meadowgrain,{W}{W}, Creature-Kithin Knight,2/2,first strike,lifelink
-139715
-139715
-139715
-139715
-#4x Wizened Cenn,{W}{W}, Creature - Kithin Cleric,2/2, other kithin get +1/+1
+#4x Wizened Cenn,{W}{W}, Creature - Kithkin Cleric,2/2, other kithin get +1/+1
 139716
 139716
 139716
 139716
-#4x Zealous Guardian,{WU}, Creature - Kithin Soldier,1/1,flash
+#4x Zealous Guardian,{WU}, Creature - Kithkin Soldier,1/1,flash
 142028
 142028
 142028
 142028
-#4x Ballynock Cohort,{2}{W},Creature - Kithin Soldier,2/2,First strike, get +1/+1 aslongas you control another white creature
+#4x Ballynock Cohort,{2}{W},Creature - Kithkin Soldier,2/2,First strike, get +1/+1 aslongas you control another white creature
 142045
 142045
 142045
 142045
-#2x Armored Ascension,{3}{W},Enchant creature, +1/+1 for each plains and flying
+#4x Armored Ascension,{3}{W},Enchant creature, +1/+1 for each plains and flying
 146041
 146041
-#2x Oversoul of Dusk,{WG}{WG}{WG}{WG}{WG},5/5, Creature - Spirit avatar, protection from blue,red and black
-146735
-146735
-#4x Thistledown Liege,{1}{WU}{WU}{WU}, 1/3, creature - Kithin Knight, give +1/+1 to blue and white creature you control
+146041
+146041
+#4x Thistledown Liege,{1}{WU}{WU}{WU}, 1/3, creature - Kithkin Knight, give +1/+1 to blue and white creature you control
 147409
 147409
 147409
 147409
+#4x Kihtkin Shielddare, {1}{W},1/1 creature - Kithkin soldier, {t}{W}:target blocking creature gets +2/+2
+158238
+158238
+158238
+158238
+#4x Goldmeadow Harrier, {W},1/1 creature - Kithkin soldier,{W}:tap target creature
+139397
+139397
+139397
+139397
+#4x Field Marshall, {1}{W}{W}, 2/2 creature - Human soldier, Other Soldier creatures get +1/+1 and have first strike
+135258
+135258
+135258
+135258
+#4x Mobilization, {2}{W}, enchantment, Soldier creatures have vigilance, {2}{W}:Put a 1/1 white Soldier creature token into play
+129716
+129716
+129716
+129716
 #20x Plains (10E)
 129683
 129683

--- a/projects/mtg/bin/Res/ai/baka/deck26.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck26.txt
@@ -1,78 +1,90 @@
-#NAME:Kithkin
-#DESC:Led by the Cenn,
-#DESC:united by the thoughtweft,
-#DESC:challenge just one 
-#DESC:champion of Goldmeadow,
-#DESC:and you will face 
-#DESC:the entire cla-chan!
-#4x Glorious Anthem, {1}{W}{W}, Enchantment, Creatures you control get +1/+1
-129572
-129572
-129572
-129572
-#4x Wizened Cenn,{W}{W}, Creature - Kithkin Cleric,2/2, other kithin get +1/+1
-139716
-139716
-139716
-139716
-#4x Zealous Guardian,{WU}, Creature - Kithkin Soldier,1/1,flash
-142028
-142028
-142028
-142028
-#4x Ballynock Cohort,{2}{W},Creature - Kithkin Soldier,2/2,First strike, get +1/+1 aslongas you control another white creature
-142045
-142045
-142045
-142045
-#4x Armored Ascension,{3}{W},Enchant creature, +1/+1 for each plains and flying
-146041
-146041
-146041
-146041
-#4x Thistledown Liege,{1}{WU}{WU}{WU}, 1/3, creature - Kithkin Knight, give +1/+1 to blue and white creature you control
-147409
-147409
-147409
-147409
-#4x Kihtkin Shielddare, {1}{W},1/1 creature - Kithkin soldier, {t}{W}:target blocking creature gets +2/+2
-158238
-158238
-158238
-158238
-#4x Goldmeadow Harrier, {W},1/1 creature - Kithkin soldier,{W}:tap target creature
-139397
-139397
-139397
-139397
-#4x Field Marshall, {1}{W}{W}, 2/2 creature - Human soldier, Other Soldier creatures get +1/+1 and have first strike
-135258
-135258
-135258
-135258
-#4x Mobilization, {2}{W}, enchantment, Soldier creatures have vigilance, {2}{W}:Put a 1/1 white Soldier creature token into play
-129716
-129716
-129716
-129716
-#20x Plains (10E)
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
-129683
+#NAME:Atarka Commander
+#DESC:Atarka's dragons bring death
+#DESC:from the air. Can you defeat
+#DESC:her?
+#DESC: 
+#DESC:Win Wagic duels to unlock
+#DESC:more Commander opponents
+#DESC:
+#DESC:Draconic Destruction 
+#DESC:Precon deck, 2022
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+Akoum Hellkite (*) * 1
+Arcane Signet (*) * 1
+Atarka Monument (*) * 1
+Beast Within (*) * 1
+Bower Passage (*) * 1
+Bristling Backwoods (*) * 1
+Chain Reaction (*) * 1
+Cinder Glade (*) * 1
+Command Tower (*) * 1
+Commander's Sphere (*) * 1
+Crucible of Fire (ALA) (*) * 1
+Cultivate (*) * 1
+Demanding Dragon (*) * 1
+Draconic Disciple (*) * 1
+Dragon Mage (*) * 1
+Dragon Tempest (*) * 1
+Dragon's Hoard (*) * 1
+Dragonkin Berserker (*) * 1
+Dragonlord's Servant (*) * 1
+Dragonmaster Outcast (*) * 1
+Dragonspeaker Shaman (*) * 1
+Drakuseth, Maw of Flames (*) * 1
+Drumhunter (*) * 1
+Elemental Bond (*) * 1
+Fervor (*) * 1
+Flameblast Dragon (ALA) (*) * 1
+Foe-Razer Regent (*) * 1
+Forest (BLB) (*) * 4
+Forest (MKM) (*) * 4
+Forest (LCI) (*) * 4
+Furnace Whelp (10E) (*) * 1
+Game Trail (*) * 1
+Garruk's Uprising (*) * 1
+Harbinger of the Hunt (*) * 1
+Harmonize (*) * 1
+Hoard-Smelter Dragon (*) * 1
+Hunter's Insight (*) * 1
+Hunter's Prowess (*) * 1
+Kazandu Refuge (*) * 1
+Kodama's Reach (CHK) (*) * 1
+Lathliss, Dragon Queen (*) * 1
+Lightning Bolt (*) * 1
+Llanowar Elves (*) * 1
+Magmaquake (C14) (*) * 1
+Mordant Dragon (*) * 1
+Mountain (BLB) (*) * 4
+Mountain (MKM) (*) * 4
+Mountain (LCI) (*) * 4
+Mountain (WOE) (*) * 4
+Mountain (LTR) (*) * 2
+Primal Might (*) * 1
+Rapacious Dragon (*) * 1
+Return to Nature (*) * 1
+Rugged Highlands (*) * 1
+Runehorn Hellkite (*) * 1
+Sakura-Tribe Elder (*) * 1
+Sarkhan, the Dragonspeaker (*) * 1
+Savage Ventmaw (*) * 1
+Scourge of Valkas (*) * 1
+Shamanic Revelation (*) * 1
+Shivan Devastator (*) * 1
+Shivan Oasis (*) * 1
+Sol Ring (*) * 1
+Spit Flame (*) * 1
+Steel Hellkite (*) * 1
+Sweltering Suns (*) * 1
+Swiftfoot Boots (*) * 1
+Talisman of Impulse (*) * 1
+Temple of Abandon (*) * 1
+Thunderbreak Regent (*) * 1
+Thundermaw Hellkite (*) * 1
+Timber Gorge (*) * 1
+Tyrant's Familiar (*) * 1
+Unleash Fury (*) * 1
+Vandalblast (*) * 1
+Verix Bladewing (*) * 1
+Wooded Ridgeline (*) * 1
+#CMD:Atarka, World Render (*) * 1


### PR DESCRIPTION
A new AI commander deck as deck26.  Deck26 itself moved to become deck18, replacing a very similar deck with mostly the same cards.