### PR TITLE
Moved AI Commander deck and added new AI Classic deck

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck150.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck150.txt
@@ -1,85 +1,27 @@
-#NAME:Ragavan Commander 2023 
-#DESC:The Ragavan Commander Deck
-#DESC:Refined for Wagic by Bob
-#HINT:castpriority(commander,*)
-Treasure Nabber (PZ2) *1
-Dire Fleet Daredevil (AFC) *1
-Trash for Treasure (C16) *1
-Tome of Legends (ELD) *1
-Helm of the Host (DOM) *1
-Coercive Recruiter (CMR) *1
-World at War (ROE) *1
-Commander's Plate (CMR) *1
-Neheb, the Eternal (AKR) *1
-Strike It Rich (MH2) *1
-Stolen Strategy *1
-Shinka, the Bloodsoaked Keep (CHK) *1
-Inventors' Fair (KLD) *1
-Strip Mine (EXP) *1
-Embercleave (ELD) *1
-Break Through the Line (FRF) *1
-Valakut, the Molten Pinnacle (ZEN) *1
-Imperial Recruiter (ME2) *1
-Tibalt's Trickery (KHM) *1
-Mogg Salvage (NMS) *1
-Seize the Day (ODY) *1
-Mishra's Bauble (MB1) *1
-Hellkite Tyrant (GTC) *1
-Goblin Engineer (MH1) *1
-Aggravated Assault (ONS) *1
-Xorn (AFR) *1
-Chromatic Lantern *1
-Magda, Brazen Outlaw (KHM) *1
-Sensei's Divining Top (EMA) *1
-Combat Celebrant (AKR) *1
-Blood Moon (2XM) *1
-Access Tunnel (STX) *1
-Sword of Hearth and Home (MH2) *1
-Mox Opal (2XM) *1
-Treasure Vault (AFR) *1
-Sword of Fire and Ice (2XM) *1
-Urza's Saga (MH2) *1
-Jeska's Will (CMR) *1
-Sol Ring (C19) *1
-Seize the Spoils (KHM) *1
-Abrade (PLIST) *1
-Fury of the Horde (CSP) *1
-Valakut Awakening (ZNR) *1
-Mountain (UNH) *20
-Godo, Bandit Warlord (CHK) *1
-Mox Amber (DOM) *1
-Breeches, Brazen Plunderer *1
-Cursed Mirror (C21) *1
-Price of Glory (ODY) *1
-Spire of Industry (AER) *1
-Vandalblast (AFC) *1
-Ancient Tomb (ZNE) *1
-Passionate Archaeologist *1
-Mana Confluence (CMR) *1
-Shatterskull Smashing (ZNR) *1
-Thran Dynamo *1
-Lightning Greaves (MB1) *1
-Pirate's Pillage (RIX) *1
-Shatter *1
-Sword of Feast and Famine (MPS) *1
-Goblin Tunneler *1
-War's Toll (BBD) *1
-Wayfarer's Bauble (C17) *1
-Cathedral of War (M13) *1
-Sword of Light and Shadow (2XM) *1
-Underworld Breach (THB) *1
-Reckless Fireweaver *1
-Dockside Extortionist (C19) *1
-Mox Diamond (FVR) *1
-Bloodstained Mire (ONS) *1
-Lightning Bolt (ME1) *1
-City of Brass (ME4) *1
-Goldspan Dragon (KHM) *1
-Ruby Medallion (C14) *1
-Sword of the Animist (AFC) *1
-Grenzo, Havoc Raiser (PZ2) *1
-Ancient Copper Dragon *1
-Moraug, Fury of Akoum (ZNR) *1
-Wheel of Fortune (VMA) *1
-Port Razer (CMR) *1
-#CMD:Ragavan, Nimble Pilferer (MH2) *1
+#NAME:Rising Panic
+#DESC: Deck for Wagic by Bob
+#HINT:castpriority(artifact,instant,enchantment)
+#HINT:combo hold(Rising Waters|myhand)^cast(Rising Waters|myhand)^restriction{type(Rising Waters|mybattlefield)~lessthan~1}^totalmananeeded({3}{U})
+#HINT:combo hold(Dictate of Kruphix|myhand)^cast(Dictate of Kruphix|myhand)^restriction{type(Dictate of Kruphix|mybattlefield)~lessthan~1}^totalmananeeded({1}{U}{U})
+#HINT:combo hold(Frozen Aether|myhand)^cast(Frozen Aether|myhand)^restriction{type(Frozen Aether|mybattlefield)~lessthan~1}^totalmananeeded({3}{U})
+#HINT:combo hold(Propaganda|myhand)^cast(Propaganda|myhand)^restriction{type(Propaganda|mybattlefield)~lessthan~1}^totalmananeeded({2}{U})
+#HINT:combo hold(Overburden|myhand)^cast(Overburden|myhand)^restriction{type(Overburden|mybattlefield)~lessthan~1}^totalmananeeded({1}{U})
+#HINT:combo hold(Dream Tides|myhand)^cast(Dream Tides|myhand)^restriction{type(Dream Tides|mybattlefield)~lessthan~1}^totalmananeeded({1}{U})
+Anvil of Bogardan (*) * 2
+Black Vise (*) * 4
+Dictate of Kruphix (*) * 3
+Dream Tides (*) * 3
+Ebony Owl Netsuke (*) * 2
+Force of Will (*) * 4
+Frozen Aether (*) * 3 
+Howling Mine (*) * 4
+Iron Maiden (*) * 2
+Island (4ED) (*) * 4
+Island (M10) (*) * 4
+Island (ICE) (*) * 4
+Island (M20) (*) * 4
+Island (MIR) (*) * 4
+Island (REV) (*) * 3
+Overburden (*) * 3
+Propaganda (*) * 3
+Rising Waters (*) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck34.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck34.txt
@@ -1,55 +1,96 @@
-#NAME:Kobold Overlord
-#DESC:"You may think we are weak
-#DESC: But we are many
-#DESC: And sometimes we can hire
-#DESC: A powerful mercenary!"
-
-# Cards considered, but not included:
-# Orcish Oriflamme - would match the deck's focus of
-#   strengthening the creatures, but is too expensive. Perhaps add
-#   it when mana acceleration is possible for this deck.
-
-# Cards removed from he deck:
-# 3 x Bravado (USG) (ID 5848)
-# The card's name and illustration don't really fit the "kobold"
-# theme, but the effect (strength through numbers) definitely
-# does.
-# Removed because the AI casts it on its opponent's creatures.
-
-# 4 x Brightstone Ritual (ONS) (ID 39846)
-# for mana acceleration
-# Removed because the AI doesn't use the mana.
-# Also ... only works with goblins. Duh. *blush*
-
-# Land(s)
-Kher Keep (TSP) * 2 # produces kobold tokens
-Mountain (ONS) * 20 
-
-# Creature(s)
-Battle Squadron (MMQ) * 2
-Crimson Kobolds (ME3) * 4
-Crookshank Kobolds (ME1) * 4
-Keldon Warlord (5ED) * 2
-#   Doesn't fit the theme too well (would a Keldon Warlord really
-#   work as a mercenary for a Kobold Overlord?), but without it
-#   the deck would be too weak, and a deck full of weak
-#   creatures is exactly the environment where a Keldon Warlord
-#   thrives.
-
-Kobold Drill Sergeant (ME3) * 4
-Kobold Overlord (ME3) * 4
-Kobold Taskmaster (ME3) * 4
-Kobolds of Kher Keep (ME3) * 4
-
-# Artifact(s)
-Howling Mine (7ED) * 4
-Slate of Ancestry (ONS) * 2
-#To draw more cards (check whether the AI overuses it and
-#decks itself out)
-
-# Sorcery(s)
-Mob Justice (*) * 3
-Wheel of Fortune (VMA) * 1
-#To get a new hand (hopefully) full of cheap kobolds once the
-#previous hand has been used up. Only 1 because it's
-#restricted.
+#NAME:Ragavan Commander 
+#DESC:Ragavan's pirates steal both
+#DESC:treasure and your spells!
+#DESC:Can you defeat him?
+#DESC: 
+#DESC:Win Wagic duels to unlock
+#DESC:more Commander opponents
+#DESC:
+#DESC:The Ragavan Commander Deck
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+Abrade (PLIST) *1
+Academy Manufactor *1
+Access Tunnel (STX) *1
+Aggravated Assault (ONS) *1
+Ancient Copper Dragon *1
+Ancient Tomb (ZNE) *1
+Arcane Signet *1
+Blood Moon (2XM) *1
+Bloodstained Mire (ONS) *1
+Break Through the Line (FRF) *1
+Breeches, Brazen Plunderer *1
+Captain Lannery Storm *1
+Cathedral of War (M13) *1
+Chromatic Lantern *1
+City of Brass (ME4) *1
+Coercive Recruiter (CMR) *1
+Combat Celebrant (AKR) *1
+Commander's Plate (CMR) *1
+Cursed Mirror (C21) *1
+Dire Fleet Daredevil (AFC) *1
+Dockside Extortionist (C19) *1
+Dwarven Mine *1
+Embercleave (ELD) *1
+Fellwar Stone *1
+Fury of the Horde (CSP) *1
+Goblin Engineer (MH1) *1
+Goblin Tunneler *1
+Godo, Bandit Warlord (CHK) *1
+Goldspan Dragon (KHM) *1
+Grenzo, Havoc Raiser (PZ2) *1
+Hellkite Tyrant (GTC) *1
+Helm of the Host (DOM) *1
+Imperial Recruiter (ME2) *1
+Inventors' Fair (KLD) *1
+Lightning Bolt (ME1) *1
+Lightning Greaves (MB1) *1
+Magda, Brazen Outlaw (KHM) *1
+Mana Confluence *1
+Mishra's Bauble (MB1) *1
+Mogg Salvage (NMS) *1
+Moraug, Fury of Akoum (ZNR) *1
+Mountain (UNH) *4
+Mountain (WOE) *4
+Mountain (LCI) *4
+Mountain (MKM) *4
+Mountain (BLB) *4
+Mox Amber (DOM) *1
+Mox Diamond (FVR) *1
+Mox Opal (2XM) *1
+Neheb, the Eternal (AKR) *1
+Passionate Archaeologist *1
+Pirate's Pillage (RIX) *1
+Port Razer (CMR) *1
+Price of Glory (ODY) *1
+Reckless Fireweaver *1
+Seize the Day (ODY) *1
+Seize the Spoils (KHM) *1
+Shatter *1
+Shinka, the Bloodsoaked Keep (CHK) *1
+Sol Ring (C19) *1
+Spire of Industry (AER) *1
+Stolen Strategy *1
+Strike It Rich (MH2) *1
+Strip Mine (EXP) *1
+Sword of Feast and Famine (MPS) *1
+Sword of Fire and Ice (2XM) *1
+Sword of Hearth and Home (MH2) *1
+Sword of Light and Shadow (2XM) *1
+Sword of the Animist (AFC) *1
+Thran Dynamo *1
+Tome of Legends (ELD) *1
+Trash for Treasure (C16) *1
+Treasure Nabber (PZ2) *1
+Treasure Vault (AFR) *1
+Underworld Breach (THB) *1
+Urza's Saga (MH2) *1
+Valakut Awakening (ZNR) *1
+Valakut, the Molten Pinnacle (ZEN) *1
+Vandalblast (AFC) *1
+War's Toll (BBD) *1
+Wayfarer's Bauble (C17) *1
+Wheel of Fortune (VMA) *1
+World at War (ROE) *1
+Xorn (AFR) *1
+#CMD:Ragavan, Nimble Pilferer (MH2) *1


### PR DESCRIPTION
Ragavan Commander AI deck moved to deck34, replacing very poor AI opponent.  New AI Classic deck becomes deck150 in place of moved Ragavan deck