### PR TITLE
New, Updated and Moved AI Decks

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck143.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck143.txt
@@ -1,83 +1,23 @@
-#NAME:Ranar Commander 2023
-#DESC:Kaldheim Commander Deck
-#DESC:Phantom Premonition
-#HINT:castpriority(commander,*)
-#HINT:dontattackwith(Ranar the Ever-Watchful)
-#HINT:dontblockwith(Ranar the Ever-Watchful)
-Angel of Finality (*) * 1
-Angel of Serenity (*) * 1
-Arcane Artisan (*) * 1
-Arcane Signet (*) * 1
-Azorius Chancery (*) * 1
-Azorius Guildgate (*) * 1
-Azorius Signet (*) * 1
-Banishing Light (*) * 1
-Behold the Multiverse (*) * 1
-Brago, King Eternal (*) * 1
-Burnished Hart (*) * 1
-Cleansing Nova (*) * 1
-Cloudblazer (*) * 1
-Cloudgoat Ranger (*) * 1
-Command Tower (*) * 1
-Commander's Sphere (*) * 1
-Cosmic Intervention (*) * 1
-Cryptic Caves (*) * 1
-Curse of the Swine (*) * 1
-Day of the Dragons (*) * 1
-Eerie Interlude (*) * 1
-Empyrean Eagle (*) * 1
-Ethereal Valkyrie (*) * 1
-Evangel of Heliod (*) * 1
-Flickerwisp (*) * 1
-Gates of Istfell (*) * 1
-Geist-Honored Monk (*) * 1
-Ghostly Flicker (*) * 1
-Ghostly Prison (*) * 1
-Glacial Floodplain (*) * 1
-Goldnight Commander (*) * 1
-Hero of Bretagard (*) * 1
-Inspired Sphinx (*) * 1
-Iron Verdict (*) * 1
-Island (*) * 12
-Kor Cartographer (*) * 1
-Marble Diamond (*) * 1
-Marshal's Anthem (*) * 1
-Meandering River (*) * 1
-Meteor Golem (*) * 1
-Migratory Route (*) * 1
-Mind Stone (*) * 1
-Mist Raven (*) * 1
-Mistmeadow Witch (*) * 1
-Momentary Blink (*) * 1
-Mulldrifter (*) * 1
-Myriad Landscape (*) * 1
-Niko Defies Destiny (*) * 1
-Opal Palace (*) * 1
-Plains (*) * 13
-Ravenform (*) * 1
-Replicating Ring (*) * 1
-Restoration Angel (*) * 1
-Return to Dust (*) * 1
-Sage of the Beyond (*) * 1
-Saw It Coming (*) * 1
-Sea Gate Oracle (*) * 1
-Sejiri Refuge (*) * 1
-Sky Diamond (*) * 1
-Sol Ring (*) * 1
-Soulherder (*) * 1
-Spectral Deluge (*) * 1
-Stoic Farmer (*) * 1
-Storm Herd (*) * 1
-Sun Titan (*) * 1
-Surtland Elementalist (*) * 1
-Swiftfoot Boots (*) * 1
-Synthetic Destiny (*) * 1
-Tales of the Ancestors (*) * 1
-Thunderclap Wyvern (*) * 1
-Tranquil Cove (*) * 1
-Vega, the Watcher (*) * 1
-Wall of Omens (*) * 1
-Warhorn Blast (*) * 1
-Whirler Rogue (*) * 1
-Windfall (*) * 1
-#CMD:Ranar the Ever-Watchful (*) * 1
+#NAME:Ashenmoor
+#DESC:Deck for Wagic by Bob
+#HINT:combo hold(Demonic Tutor|myhand)^cast(Demonic Tutor|myhand) targeting(Ashenmoor Liege|mylibrary)^totalmananeeded({1}{B})
+#HINT:alwaysattackwith(Ashenmoor Gouger)
+#HINT:dontblockwith(Ashenmoor Liege)
+Ashenmoor Gouger (*) * 4
+Ashenmoor Liege (*) * 4
+Badlands (*) * 4
+Demonic Tutor (CMM) (*) * 2
+Dragonskull Summit (*) * 4
+Emberstrike Duo (*) * 4
+Footlight Fiend (*) * 4
+Glass of the Guildpact (*) * 4
+Goblin Outlander (*) * 2
+Mountain (DSK) (*) * 4
+Mountain (MKM) (*) * 2
+Rakdos Cackler (*) * 4
+Rakdos Shred-Freak (*) * 4
+Shivan Zombie (*) * 2
+Spike Jester (*) * 4
+Swamp (DSK) (*) * 4
+Swamp (MKM) (*) * 2
+Terminate (2X2) (*) * 2

--- a/projects/mtg/bin/Res/ai/baka/deck149.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck149.txt
@@ -1,92 +1,26 @@
-#NAME:Tatyova Commander 
-#DESC:The Tatyova Commander Deck
-#DESC:Refined for Wagic by Bob
-#HINT:castpriority(commander,*)
-#HINT:combo hold(Finale of Devastation|myhand)^cast(Finale of Devastation|myhand) targeting(Worldspine Wurm|mylibrary)~totalmananeeded({11}{G}{G})
-#HINT:combo hold(Genesis Wave|myhand)^cast(Genesis Wave|myhand)~totalmananeeded({5}{G}{G}{G})
-Arcane Signet (AFC) *1
-Avenger of Zendikar (PRM) *1
-Azusa, Lost but Seeking *1
-Birds of Paradise (PRM) *1
-Broken Bond (MB1) *1
-Castle Vantress (ELD) *1
-Command Beacon (PZ1) *1
-Command Tower (C19) *1
-Consecrated Sphinx (MBS) *1
-Courser of Kruphix (TSR) *1
-Crop Rotation (2XM) *1
-Crucible of Worlds (PRM) *1
-Cultivate (PZ1) *1
-Cyclonic Rift (MM3) *1
-Decanter of Endless Water *1
-Dryad Arbor (TSR) *1
-Echoing Truth (C19) *1
-Eternal Witness (PZ1) *1
-Exploration (PRM) *1
-Explore (C19) *1
-Finale of Devastation (WAR) *1
-Flooded Grove (EXP) *1
-Flooded Strand (EXP) *1
-Force of Will (EMA) *1
-Forest (2XM) *4
-Forest (BLB) *4
-Forest (OTJ) *3
-Gaea's Cradle (USG) *1
-Genesis Wave (IMA) *1
-Harmonize (PRM) *1
-Harrow (MB1) *1
-Hinterland Harbor *1
-Island (UNH) *4
-Island (OTJ) *4
-Island (BLB) *1
-Khalni Garden (PZ1) *1
-Kinnan, Bonder Prodigy (IKO) *1
-Kodama's Reach (C17) *1
-Koma, Cosmos Serpent (KHM) *1
-Lightning Greaves (AFC) *1
-Lotus Cobra (PRM) *1
-Mana Reflection (SHM) *1
-Misty Rainforest (ZNE) *1
-Multani, Yavimaya's Avatar *1
-Mystic Sanctuary (ELD) *1
-Narset, Parter of Veils (WAR) *1
-Nexus of Fate (M19) *1
-Nyxbloom Ancient (THB) *1
-Oran-Rief Hydra *1
-Polluted Delta (ONS) *1
-Pongify (TSR) *1
-Primeval Titan (TSR) *1
-Prismatic Vista (H1R) *1
-Prophet of Kruphix (PRM) *1
-Rampaging Baloths (C19) *1
-Rampant Growth (PRM) *1
-Ramunap Excavator (PRM) *1
-Reliquary Tower (C19) *1
-Rimewood Falls (KHM) *1
-Ruin Crab *1
-Sakura-Tribe Elder (MB1) *1
-Scalding Tarn (MH2) *1
-Search for Tomorrow (MB1) *1
-Seedborn Muse (C19) *1
-Simic Growth Chamber (C19) *1
-Simic Signet (C15) *1
-Sol Ring (C19) *1
-Solemn Simulacrum (MB1) *1
-Sporemound *1
-Strip Mine (EXP) *1
-Summer Bloom (POR) *1
-Sylvan Scrying (MB1) *1
-Tangled Islet *1
-Thran Dynamo *1
-Thrasios, Triton Hero (PZ2) *1
-Timetwister (PRM) *1
-Tropical Island (ME4) *1
-Tyrite Sanctum (KHM) *1
-Upheaval (MH2) *1
-Verdant Catacombs (MH2) *1
-Wayfarer's Bauble (C17) *1
-Wild Growth (AFC) *1
-Worldspine Wurm *1
-Yavimaya Elder (UDS) *1
-Zendikar's Roil *1
-#CMD:Tatyova, Benthic Druid (DOM) *1
+#NAME:Shocking Minotaurs
+#DESC:Deck for Wagic by Bob
+#HINT:combo hold(Raise Dead|myhand)^cast(Raise Dead|myhand)^restriction{type(creature[toughness>=2]|mygraveyard)~morethan~0}~totalmananeeded({B})
+Badlands (*) * 1
+Blackcleave Cliffs (*) * 2
+Bloodrage Brawler (*) * 4
+Dragonskull Summit  (*) * 2
+Fanatic of Mogis (*) * 1
+Felhide Petrifier (*) * 2
+Gnarled Scarhide (*) * 2
+Kragma Warcaller (*) * 4
+Lightning Bolt (*) * 4
+Mogis, God of Slaughter (*) * 2
+Moraug, Fury of Akoum (*) * 1
+Mountain (DSK) (*) * 4
+Mountain (MKM) (*) * 3
+Mountain (WOE) (*) * 4
+Neheb, the Eternal (*) * 1
+Neheb, the Worthy (*) * 3
+Rageblood Shaman (*) * 4
+Ragemonger (*) * 4
+Raise Dead (9ED) (*) * 2
+Shock (*) * 2
+Swamp (DSK) (*) * 4
+Swamp (WOE) (*) * 2
+Terminate (NCC) (*) * 2

--- a/projects/mtg/bin/Res/ai/baka/deck156.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck156.txt
@@ -1,57 +1,91 @@
-#NAME:Lord of The Rings Commander 2023
-#DESC:Original Deck Concept by ElderKuradio (tappedout.net)
-#DESC:Designed for Wagic by Vitty85
-#HINT:castpriority(commander,creature,*)
-Aragorn and Arwen, Wed (*) * 1
-Aragorn, the Uniter (*) * 1
-Arwen, Mortal Queen (*) * 1
-Elvish Mariner (*) * 1
-Frodo, Determined Hero (*) * 1
-Galadriel, Gift-Giver (*) * 1
-Gandalf the White (*) * 1
-Gandalf, White Rider (*) * 1
-Gloin, Dwarf Emissary (*) * 1
-Gollum, Scheming Guide (*) * 1
-Gorbag of Minas Morgul (*) * 1
+#NAME:Sauron Commander
+#DESC:Original deck by Josh 
+#DESC:Edmundson (tappedout.net)
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+Abrade (*) * 1
+An Offer You Can't Refuse (*) * 1
+Arcane Denial (*) * 1
+Arcane Signet (*) * 1
+Badlands (*) * 1
+Bedevil (*) * 1
+Big Score (*) * 1
+Bone Miser (*) * 1
+Callous Dismissal (*) * 1
+Changeling Outcast (*) * 1
+Chromatic Lantern (*) * 1
+Command Tower (*) * 1
+Commander's Sphere (*) * 1
+Crumbling Necropolis (*) * 1
+Dragonskull Summit (*) * 1
+Dreadhorde Invasion (*) * 1
+Drowned Catacomb (*) * 1
+Eternal Skylord (*) * 1
+Evolving Wilds (*) * 1
+Exotic Orchard (*) * 1
+Faithless Looting (*) * 1
+Feed the Swarm (*) * 1
+Fellwar Stone (*) * 1
+Foray of Orcs (*) * 1
+Gleaming Overseer (*) * 1
 Gothmog, Morgul Lieutenant (*) * 1
-Gwaihir the Windlord (*) * 1
-Ioreth of the Healing House (*) * 1
-Rangers of Ithilien (*) * 1
-Saruman of Many Colors (*) * 1
+Grishnakh, Brash Instigator (*) * 1
+Haunted Ridge (*) * 1
+Herald of Secret Streams (*) * 1
+Honor the God-Pharaoh (*) * 1
+Infernal Grasp (*) * 1
+Inherited Envelope (*) * 1
+Island (LTR) (*) * 4
+Island (WOE) (*) * 1
+Lazotep Chancellor (*) * 1
+Lazotep Plating (*) * 1
+March from the Black Gate (*) * 1
+Mauhur, Uruk-hai Captain (*) * 1
+Mindless Conscription (*) * 1
+Mithril Coat (*) * 1
+Mountain (LTR) (*) * 4
+616930
+619388
+619389
+619390
+619391
+619392
+619393
+619394
+619395
+Orcish Bowmasters (*) * 1
+Orcish Siegemaster (*) * 1
+Ringsight (*) * 1
 Saruman the White (*) * 1
-Sauron, the Dark Lord (*) * 1
-Sauron, the Lidless Eye (*) * 1
-Strider, Ranger of the North (*) * 1
-Witch-king of Angmar (*) * 1
+Saruman's Trickery (*) * 1
+Saruman, the White Hand (*) * 1
+Sauron, Lord of the Rings (*) * 1
+Sauron, the Necromancer (*) * 1
+Sheoldred, Whispering One (*) * 1
+Shipwreck Marsh (*) * 1
+Shivan Reef (*) * 1
+Smoldering Marsh (*) * 1
+Sol Ring (*) * 1
+Stormcarved Coast (*) * 1
+Sulfurous Springs (*) * 1
+Sunken Hollow (*) * 1
+Swamp (LTR) (*) * 4
+Swamp (WOE) (*) * 4
+Swamp (DSK) (*) * 3
+Swarming of Moria (*) * 1
+Talisman of Creativity (*) * 1
+Talisman of Dominance (*) * 1
+Talisman of Indulgence (*) * 1
+Teferi's Ageless Insight (*) * 1
+Temple of Epiphany (*) * 1
+The Locust God (*) * 1
+Thrill of Possibility (*) * 1
+Ulamog, The Infinite Gyre (*) * 1
+Underground River (*) * 1
+Underground Sea (*) * 1
+Vandalblast (*) * 1
+Whispersilk Cloak (*) * 1
+Widespread Brutality (*) * 1
+Windfall (*) * 1
 Witch-king, Bringer of Ruin (*) * 1
-Barad-dur (*) * 1
-Mount Doom (*) * 1
-Mountain (LTR) * 13
-Island (LTR) * 10
-Swamp (LTR) * 10
-Forest (LTR) * 10
-Plains (LTR) * 10
-Elven Chorus (*) * 1
-Fires of Mount Doom (*) * 1
-Gift of Strands (*) * 1
-Long List of the Ents (*) * 1
-Oath of the Grey Host (*) * 1
-Scroll of Isildur (*) * 1
-War of the Last Alliance (*) * 1
-Borne Upon a Wind (*) * 1
-Friendly Rivalry (*) * 1
-Press the Enemy (*) * 1
-Sauron's Ransom (*) * 1
-Stern Scolding (*) * 1
-You Cannot Pass! (*) * 1
-Assault on Osgiliath (*) * 1
-Hew the Entwood (*) * 1
-Horses of the Bruinen (*) * 1
-Last March of the Ents (*) * 1
-Shadow Summoning (*) * 1
-Shadow of the Enemy (*) * 1
-Bilbo's Ring (*) * 1
-Glamdring (*) * 1
-Palantir of Orthanc (*) * 1
-
-#CMD:Tom Bombadil (*) * 1
+#CMD:Sauron, the Dark Lord (*) * 1

--- a/projects/mtg/bin/Res/ai/baka/deck46.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck46.txt
@@ -1,49 +1,92 @@
-#NAME:Ashenmoor Cohort
-#
-#DESC: How does it feel
-#DESC: to be dead
-#DESC: I hear you ask?
-#DESC: 
-#DESC: It hurts.
-#DESC: It burns.
-#DESC: 
-#DESC: It makes you ...
-#DESC: ... want to come back.
-
-Ashenmoor Cohort (SHM)   *2  # lots of Cinder creatures
-Ashenmoor Gouger (SHM)   *3
-Corrosive Mentor (SHM)   *3
-Crowd of Cinders (SHM)   *4
-Smoldering Butcher (EVE) *4
-Emberstrike Duo (SHM)    *3  # gets pumped by red or black spells
-Nyxathid (CFX)           *2
-Sickle Ripper (SHM)      *3
-Spiteflame Witch (SHM)   *2
-Soul Snuffers (EVE)      *2  # dangerous for the AI
-
-Scar (SHM)               *4  # cheap red/black damage spell
-Haunted Crossroads (MRQ) *2  # compensates for Soul Snuffers
-Raise Dead (RV)          *2  # compensates for Soul Snuffers
-
-
-Swamp (10E) *24
-
-
-# Cards considered, but not included:
-# Cinderbones: Expensive and weak in this deck
-# Sootstoke Kindler - AI can't choose target well
-# Fulminator Mage - most lands of player will be basic for a while
-# Midnight Covenant - buggy in 0.8.1
-
-# Cards removed from the deck:
-# none
-
-# Notes:
-# The Soul Snuffers may have to be removed since the AI often
-# hurts itself with them.
-#
-# This is a pure black deck, it doesn't explore most of the
-# potential red/black synergies. I'd like to do that as well, but
-# I'd want the Ashenmoor Liege as a central card in that deck, and
-# that card isn't implemented yet. Hence, the deck is black and
-# the central creature is a black creature.
+#NAME:Tatyova Commander 
+#DESC:The Tatyova Commander Deck
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+#HINT:combo hold(Finale of Devastation|myhand)^cast(Finale of Devastation|myhand) targeting(Worldspine Wurm|mylibrary)~totalmananeeded({11}{G}{G})
+#HINT:combo hold(Genesis Wave|myhand)^cast(Genesis Wave|myhand)~totalmananeeded({5}{G}{G}{G})
+Arcane Signet (AFC) *1
+Avenger of Zendikar (PRM) *1
+Azusa, Lost but Seeking *1
+Birds of Paradise (PRM) *1
+Broken Bond (MB1) *1
+Castle Vantress (ELD) *1
+Command Beacon (PZ1) *1
+Command Tower (C19) *1
+Consecrated Sphinx (MBS) *1
+Courser of Kruphix (TSR) *1
+Crop Rotation (2XM) *1
+Crucible of Worlds (PRM) *1
+Cultivate (PZ1) *1
+Cyclonic Rift (MM3) *1
+Decanter of Endless Water *1
+Dryad Arbor (TSR) *1
+Echoing Truth (C19) *1
+Eternal Witness (PZ1) *1
+Exploration (PRM) *1
+Explore (C19) *1
+Finale of Devastation (WAR) *1
+Flooded Grove (EXP) *1
+Flooded Strand (EXP) *1
+Force of Will (EMA) *1
+Forest (2XM) *4
+Forest (BLB) *4
+Forest (OTJ) *3
+Gaea's Cradle (USG) *1
+Genesis Wave (IMA) *1
+Harmonize (PRM) *1
+Harrow (MB1) *1
+Hinterland Harbor *1
+Island (UNH) *4
+Island (OTJ) *4
+Island (BLB) *1
+Khalni Garden (PZ1) *1
+Kinnan, Bonder Prodigy (IKO) *1
+Kodama's Reach (C17) *1
+Koma, Cosmos Serpent (KHM) *1
+Lightning Greaves (AFC) *1
+Lotus Cobra (PRM) *1
+Mana Reflection (SHM) *1
+Misty Rainforest (ZNE) *1
+Multani, Yavimaya's Avatar *1
+Mystic Sanctuary (ELD) *1
+Narset, Parter of Veils (WAR) *1
+Nexus of Fate (M19) *1
+Nyxbloom Ancient (THB) *1
+Oran-Rief Hydra *1
+Polluted Delta (ONS) *1
+Pongify (TSR) *1
+Primeval Titan (TSR) *1
+Prismatic Vista (H1R) *1
+Prophet of Kruphix (PRM) *1
+Rampaging Baloths (C19) *1
+Rampant Growth (PRM) *1
+Ramunap Excavator (PRM) *1
+Reliquary Tower (C19) *1
+Rimewood Falls (KHM) *1
+Ruin Crab *1
+Sakura-Tribe Elder (MB1) *1
+Scalding Tarn (MH2) *1
+Search for Tomorrow (MB1) *1
+Seedborn Muse (C19) *1
+Simic Growth Chamber (C19) *1
+Simic Signet (C15) *1
+Sol Ring (C19) *1
+Solemn Simulacrum (MB1) *1
+Sporemound *1
+Strip Mine (EXP) *1
+Summer Bloom (POR) *1
+Sylvan Scrying (MB1) *1
+Tangled Islet *1
+Thran Dynamo *1
+Thrasios, Triton Hero (PZ2) *1
+Timetwister (PRM) *1
+Tropical Island (ME4) *1
+Tyrite Sanctum (KHM) *1
+Upheaval (MH2) *1
+Verdant Catacombs (MH2) *1
+Wayfarer's Bauble (C17) *1
+Wild Growth (AFC) *1
+Worldspine Wurm *1
+Yavimaya Elder (UDS) *1
+Zendikar's Roil *1
+#CMD:Tatyova, Benthic Druid (DOM) *1

--- a/projects/mtg/bin/Res/ai/baka/deck68.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck68.txt
@@ -1,15 +1,83 @@
-#NAME:Shocking Minotaurs
-#DESC:The bright flash
-#DESC:  of the opening attacks
-#DESC:is followed by the deafening thunder
-#DESC:  of a multitude of hooves
-Hurloon Minotaur (RV)        * 4 #
-Anaba Spirit Crafter (HML)   * 4 #
-Talruum Minotaur (MIR)       * 4 #
-Minotaur Warrior (POR)       * 4 #
-Raging Minotaur (POR)        * 4 #
-Mountain (10E)               *24 #
-Anaba Bodyguard (10E)        * 4 #
-Burst Lightning (ZEN)        * 4 #
-Canyon Minotaur (M10)        * 4 #
-Lightning Bolt (M10)         * 4 #
+#NAME:Ranar Commander
+#DESC:Kaldheim Commander Deck
+#DESC:Phantom Premonition
+#HINT:castpriority(commander,*)
+#HINT:dontattackwith(Ranar the Ever-Watchful)
+#HINT:dontblockwith(Ranar the Ever-Watchful)
+Angel of Finality (*) * 1
+Angel of Serenity (*) * 1
+Arcane Artisan (*) * 1
+Arcane Signet (*) * 1
+Azorius Chancery (*) * 1
+Azorius Guildgate (*) * 1
+Azorius Signet (*) * 1
+Banishing Light (*) * 1
+Behold the Multiverse (*) * 1
+Brago, King Eternal (*) * 1
+Burnished Hart (*) * 1
+Cleansing Nova (*) * 1
+Cloudblazer (*) * 1
+Cloudgoat Ranger (*) * 1
+Command Tower (*) * 1
+Commander's Sphere (*) * 1
+Cosmic Intervention (*) * 1
+Cryptic Caves (*) * 1
+Curse of the Swine (*) * 1
+Day of the Dragons (*) * 1
+Eerie Interlude (*) * 1
+Empyrean Eagle (*) * 1
+Ethereal Valkyrie (*) * 1
+Evangel of Heliod (*) * 1
+Flickerwisp (*) * 1
+Gates of Istfell (*) * 1
+Geist-Honored Monk (*) * 1
+Ghostly Flicker (*) * 1
+Ghostly Prison (*) * 1
+Glacial Floodplain (*) * 1
+Goldnight Commander (*) * 1
+Hero of Bretagard (*) * 1
+Inspired Sphinx (*) * 1
+Iron Verdict (*) * 1
+Island (*) * 12
+Kor Cartographer (*) * 1
+Marble Diamond (*) * 1
+Marshal's Anthem (*) * 1
+Meandering River (*) * 1
+Meteor Golem (*) * 1
+Migratory Route (*) * 1
+Mind Stone (*) * 1
+Mist Raven (*) * 1
+Mistmeadow Witch (*) * 1
+Momentary Blink (*) * 1
+Mulldrifter (*) * 1
+Myriad Landscape (*) * 1
+Niko Defies Destiny (*) * 1
+Opal Palace (*) * 1
+Plains (*) * 13
+Ravenform (*) * 1
+Replicating Ring (*) * 1
+Restoration Angel (*) * 1
+Return to Dust (*) * 1
+Sage of the Beyond (*) * 1
+Saw It Coming (*) * 1
+Sea Gate Oracle (*) * 1
+Sejiri Refuge (*) * 1
+Sky Diamond (*) * 1
+Sol Ring (*) * 1
+Soulherder (*) * 1
+Spectral Deluge (*) * 1
+Stoic Farmer (*) * 1
+Storm Herd (*) * 1
+Sun Titan (*) * 1
+Surtland Elementalist (*) * 1
+Swiftfoot Boots (*) * 1
+Synthetic Destiny (*) * 1
+Tales of the Ancestors (*) * 1
+Thunderclap Wyvern (*) * 1
+Tranquil Cove (*) * 1
+Vega, the Watcher (*) * 1
+Wall of Omens (*) * 1
+Warhorn Blast (*) * 1
+Whirler Rogue (*) * 1
+Windfall (*) * 1
+#CMD:Ranar the Ever-Watchful (*) * 1


### PR DESCRIPTION
Tatyova and Ranar Commander AI decks are moved to lower positions so they are unlocked sooner.  The two decks previously in those positions (Ashenmoor and Shocking Minotaurs) are rebuilt and moved to the old Tatyova and Ranar slots.  A new LotR commander deck based on Sauron replaces the old LotR deck based on Tom Bombadil which was a very poor AI opponent