### PR TITLE
New, improved and renamed AI decks

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck102.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck102.txt
@@ -1,26 +1,84 @@
-#NAME:The KOR
-#DESC:The Kor never stand down.Golem-Skin Gauntlets	 (MRD) *1
-Plains	 (8ED) *4
-Plains	 (8ED) *4
-Bonesplitter	 (MRD) *2
-Vulshok Battlegear	 (MRD) *1
-Plains	 (MRD) *4
-Plains	 (MRD) *4
-Plains	 (MRD) *4
-Cranial Plating	 (5DN) *2
-Skyhunter Skirmisher	 (5DN) *2
-Paradise Mantle	 (5DN) *2
-Shuko	 (BOK) *2
-Umezawa's Jitte	 (BOK) *2
-Kor Duelist	 (ZEN) *2
-Spidersilk Net	 (ZEN) *1
-Bone Saw	 (CFX) *2
-Armament Master	 (ZEN) *3
-Lone Missionary	 (ROE) *2
-Pennon Blade	 (ROE) *1
-Kor Line-Slinger	 (ROE) *2
-Kitesail Apprentice	 (WWK) *2
-Stoneforge Mystic	 (WWK) *2
-Accorder's Shield	 (SOM) *2
-Swords to Plowshares	 (EVT) *2
-Kor Hookmaster	 (EVT) *2
+#NAME:Tergrid Commander
+#DESC:The Tergrid Commander Deck
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+Ancient Tomb (EXP) *1
+Animate Dead (VMA) *1
+Arcane Signet (AFC) *1
+Archon of Cruelty (MH2) *1
+Barren Moor (C19) *1
+Blackblade Reforged (SS2) *1
+Bojuka Bog (C19) *1
+Braids, Cabal Minion (EMA) *1
+Butcher of Malakir *1
+Charcoal Diamond *1
+Command Beacon (PZ1) *1
+Commander's Sphere (C19) *1
+Corrupt *1
+Crypt Ghast (GTC) *1
+Damnation (MM3) *1
+Dreadhorde Invasion (WAR) *1
+Elvish Doomsayer *1
+Fell Specter *1 
+Geier Reach Sanitarium (C19) *1
+Gilded Lotus *1
+Grave Pact (CMD) *1
+Gray Merchant of Asphodel *1
+Hedron Archive (C19) *1
+Hymn to Tourach *1
+Hypnotic Specter *1
+Korlash, Heir to Blackblade *1
+Leaden Myr *1
+Lightning Greaves (AFC) *1
+Liliana of the Dark Realms *1
+Liliana, Dreadhorde General (WAR) *1
+Liliana's Triumph (WAR) *1
+Lotus Petal (MB1) *1
+Megrim *1
+Memory Jar (FVR) *1
+Mind Stone (AFC) *1
+Mortuary Mire *1
+Mox Jet *1
+Necrogen Mists (MRD) *1
+Night's Whisper (EMA) *1
+No Mercy (MP2) *1
+Oppression (7ED) *1
+Painful Quandary *1
+Palladium Myr (MB1) *1
+Phyrexian Arena (TD0) *1
+Phyrexian Obliterator *1
+Plaguecrafter (C19) *1
+Pox (ME1) *1
+Ravenous Chupacabra (MB1) *1
+Reliquary Tower (M13) *1
+Sangromancer (MBS) *1
+Shadowspear (THB) *1
+Sheoldred, Whispering One *1
+Smallpox (M12) *1
+Sol Ring (C19) *1
+Solemn Simulacrum (TSR) *1
+Soul Shatter (ZNR) *1
+Steel Hellkite (C17) *1
+Strip Mine (EXP) *1
+Swamp (2XM) *4
+Swamp (OTJ) *4
+Swamp (MKM) *4
+Swamp (WOE) *4
+Swamp (LCI) *4
+Swamp (DSK) *4
+Swamp (BLB) *3
+Sword of Feast and Famine (MPS) *1
+Syr Konrad, the Grim *1
+Temple of the False God *1
+The Eldest Reborn *1
+Thought Vessel (MB1) *1
+Thoughtseize (2XM) *1
+Thran Dynamo (C19) *1
+Tinybones, Trinket Thief (JMP) *1
+Tourach, Dread Cantor (MH2) *1
+Urborg, Tomb of Yawgmoth (TSR) *1
+Whip of Erebos (THS) *1
+Witch of the Moors (JMP) *1
+Witch's Cottage (ELD) *1
+Worn Powerstone (PZ1) *1
+#CMD:Tergrid, God of Fright (KHM) *1

--- a/projects/mtg/bin/Res/ai/baka/deck124.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck124.txt
@@ -1,40 +1,81 @@
-#NAME:Wipe them out!
-#DESC:Modern RBW Control
-#HINT:castpriority(enchantment,sorcery,artifact,instant)
-#HINT:combo hold(Devour Flesh|myhand)^until(creature|opponentbattlefield)^cast(Devour Flesh|myhand)^totalmananeeded({1}{B})
-#HINT:combo hold(Pyroclasm|myhand)^cast(Pyroclasm|myhand)^restriction{type(creature[toughness<=2]|opponentbattlefield)~morethan~1}~totalmananeeded({1}{R})
-#HINT:combo hold(Wrath of God|myhand)^cast(Wrath of God|myhand)^restriction{type(creature|opponentbattlefield)~morethan~1}^totalmananeeded({2}{W}{W})
-#HINT:combo hold(Damnation|myhand)^cast(Damnation|myhand)^restriction{type(creature|opponentbattlefield)~morethan~1}^totalmananeeded({2}{B}{B})
-#HINT:combo hold(Final Judgment|myhand)^cast(Final Judgment|myhand)^restriction{type(creature|opponentbattlefield)~morethan~1}^totalmananeeded({4}{W}{W})
-
-#22 spells
-#8 2-cc
-Devour Flesh * 4
-Pyroclasm (M11) * 4
-#8 4-cc
-Damnation * 4
-Wrath of God (10E) * 4
-#2 6-cc
-Final Judgment * 2
-#4 x-cc
-Black Sun's Zenith * 2
-Rakdos's Return * 2
-
-#8 artifacts
-Elixir of Immortality * 2
-Staff of Nin * 4
-Venser's Journal * 2
-
-#4 enchantments
-Lightmine Field * 4
-
-#26 lands
-Plateau (ME4) * 4
-Badlands (ME4) * 4
-Scrubland (ME4) * 4
-Akoum Refuge * 4
-Isolated Chapel * 4
-Clifftop Retreat * 2
-Urborg, Tomb of Yawgmoth * 1
-Plains (CHK) * 2
-Swamp (RTR) * 1
+#NAME:Belbe Commander
+#DESC:Deck by apparently (tappedout.net)
+#DESC:Refined for Wagic by Bob
+#HINT:castpriority(commander,*)
+Ancient Stone Idol
+Apex Devastator
+Archetype of Endurance
+Artisan of Kozilek
+Bane of Bala Ged
+Beacon of Unrest
+Bellowing Tanglewurm
+Cabal Conditioning
+Caller of the Pack
+Colossus of Akros
+Command Tower
+Conduit of Ruin
+Copper Myr
+Court of Ambition
+Cultivate
+Dread Defiler
+Eldrazi Conscription
+Exsanguinate
+Farseek
+Fierce Empath
+Forest (4ED) *4
+Forest (NEO) *4
+Forest (ONE) *4
+Forest (SNC) *4
+Garruk's Uprising
+Gilanra, Caller of Wirewood
+God-Pharaoh's Statue
+Grave Betrayal
+Helm of the Host
+Hooded Blightfang
+Horizon Stone
+In Garruk's Wake
+Josu Vess, Lich Knight
+Kodama's Reach (CMD)
+Leaden Myr
+Leechridden Swamp
+Lim-Dul's Hex
+Loxodon Warhammer (10E)
+Loyal Subordinate
+Mardu Shadowspear
+Mirror Shield
+Night Market Lookout
+Oblivion Sower
+Pathrazer of Ulamog
+Phyrexian Juggernaut
+Phyrexian Triniform
+Plague Spitter
+Planar Bridge
+Platinum Emperion
+Polyraptor
+Pulse Tracker
+Rampant Growth
+Return of the Wildspeaker
+Sanctum of Stone Fangs
+Sandstone Oracle
+Sandwurm Convergence
+Skull Storm
+Skyclave Relic
+Sol Ring
+Staff of Nin
+Swamp (ONE) *4
+Swamp (NEO) *4
+Swamp (SNC) *4
+Swamp (4ED) *3
+The Immortal Sun
+Thornbow Archer
+Thought Vessel
+Three Visits
+Thunderfoot Baloth
+Torment of Hailfire
+Ulamog's Crusher
+Undergrowth Stadium
+Urborg, Tomb of Yawgmoth
+Vicious Conquistador
+Yavimaya, Cradle of Growth
+Zendikar Resurgent
+#CMD:Belbe, Corrupted Observer (*) *1

--- a/projects/mtg/bin/Res/ai/baka/deck140.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck140.txt
@@ -1,81 +1,28 @@
-#NAME:Belbe Commander 2023
-#DESC:Deck by apparently (tappedout.net)
-#DESC:Refined for Wagic by Bob
-#HINT:castpriority(commander,*)
-Ancient Stone Idol
-Apex Devastator
-Archetype of Endurance
-Artisan of Kozilek
-Bane of Bala Ged
-Beacon of Unrest
-Bellowing Tanglewurm
-Cabal Conditioning
-Caller of the Pack
-Colossus of Akros
-Command Tower
-Conduit of Ruin
-Copper Myr
-Court of Ambition
-Cultivate
-Dread Defiler
-Eldrazi Conscription
-Exsanguinate
-Farseek
-Fierce Empath
-Forest (4ED) *4
-Forest (NEO) *4
-Forest (ONE) *4
-Forest (SNC) *4
-Garruk's Uprising
-Gilanra, Caller of Wirewood
-God-Pharaoh's Statue
-Grave Betrayal
-Helm of the Host
-Hooded Blightfang
-Horizon Stone
-In Garruk's Wake
-Josu Vess, Lich Knight
-Kodama's Reach (CMD)
-Leaden Myr
-Leechridden Swamp
-Lim-Dul's Hex
-Loxodon Warhammer (10E)
-Loyal Subordinate
-Mardu Shadowspear
-Mirror Shield
-Night Market Lookout
-Oblivion Sower
-Pathrazer of Ulamog
-Phyrexian Juggernaut
-Phyrexian Triniform
-Plague Spitter
-Planar Bridge
-Platinum Emperion
-Polyraptor
-Pulse Tracker
-Rampant Growth
-Return of the Wildspeaker
-Sanctum of Stone Fangs
-Sandstone Oracle
-Sandwurm Convergence
-Skull Storm
-Skyclave Relic
-Sol Ring
-Staff of Nin
-Swamp (ONE) *4
-Swamp (NEO) *4
-Swamp (SNC) *4
-Swamp (4ED) *3
-The Immortal Sun
-Thornbow Archer
-Thought Vessel
-Three Visits
-Thunderfoot Baloth
-Torment of Hailfire
-Ulamog's Crusher
-Undergrowth Stadium
-Urborg, Tomb of Yawgmoth
-Vicious Conquistador
-Yavimaya, Cradle of Growth
-Zendikar Resurgent
-#CMD:Belbe, Corrupted Observer (*) *1
+#NAME:Wipe Them Out!
+#DESC:Modern RBW Control
+#HINT:castpriority(creature,enchantment,sorcery,artifact)
+#HINT:combo hold(Cruel Edict|myhand)^until(creature|opponentbattlefield)^cast(Cruel Edict|myhand)^totalmananeeded({1}{B})
+#HINT:combo hold(Pyroclasm|myhand)^cast(Pyroclasm|myhand)^restriction{type(creature[toughness<=2]|opponentbattlefield)~morethan~1}~totalmananeeded({1}{R})
+#HINT:combo hold(Wrath of God|myhand)^cast(Wrath of God|myhand)^restriction{type(creature|opponentbattlefield)~morethan~1}^totalmananeeded({2}{W}{W})
+#HINT:combo hold(Damnation|myhand)^cast(Damnation|myhand)^restriction{type(creature|opponentbattlefield)~morethan~1}^totalmananeeded({2}{B}{B})
+#HINT:alwaysattackwith(Blightsteel Colossus)
+Blightsteel Colossus * 2
+Cruel Edict (10E) * 4
+Pyroclasm *4
+Damnation * 4
+Wrath of God (10E) * 4
+Black Sun's Zenith * 2
+Rakdos's Return * 2
+Elixir of Immortality * 2
+Staff of Nin * 4
+Venser's Journal * 2
+Lightmine Field * 4
+Plateau (ME4) * 4
+Badlands (ME4) * 4
+Scrubland (ME4) * 4
+Akoum Refuge * 4
+Isolated Chapel * 4
+Clifftop Retreat * 2
+Urborg, Tomb of Yawgmoth * 1
+Plains (CHK) * 2
+Swamp (RTR) * 1

--- a/projects/mtg/bin/Res/ai/baka/deck141.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck141.txt
@@ -1,4 +1,4 @@
-#NAME:Omnath Commander 2023
+#NAME:Omnath Commander
 #DESC:Deck concept by HurricaneHands
 #DESC:(tappedout.net)
 #DESC:Refined for Wagic by Bob

--- a/projects/mtg/bin/Res/ai/baka/deck142.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck142.txt
@@ -1,104 +1,87 @@
-#NAME:Ur-Dragon Commander 2023
-#DESC:The Ur-Dragon Commander Deck
+#NAME:Lyra Commander
+#DESC:Deck by guitrunks01 
+#DESC:(archidekt.com)
 #DESC:Refined for Wagic by Bob
 #HINT:castpriority(commander,*)
-Aggravated Assault (*) * 1
-Ancient Tomb (*) * 1
-Arcane Signet (*) * 1
-Atarka, World Render (*) * 1
-Balefire Dragon (*) * 1
-Bayou
-Bladewing the Risen (*) * 1
-Bloom Tender (*) * 1
-Cascading Cataracts (*) * 1
-Chromatic Lantern (*) * 1
-Chromatic Orrery (*) * 1
-Coalition Relic (*) * 1
-Command Beacon (*) * 1
+#HINT:combo hold(Mass Calcify|myhand)^cast(Mass Calcify|myhand)^restriction{type(creature|opponentbattlefield)~morethan~2}^totalmananeeded({2}{W}{W})
+#HINT:combo hold(Blinding Light|myhand)^cast(Blinding Light|myhand)^restriction{type(creature|opponentbattlefield)~morethan~2}^totalmananeeded({3}{W}{W})
+Always Watching (*) * 1
+Akroma's Memorial (m13) (*) * 1
+Akroma, Angel of Wrath (c20) (*) * 1
+Angel of Finality (moc) (*) * 1
+Angel of Invention (kld) (*) * 1
+Angel of Jubilation (avr) (*) * 1
+Angel of Serenity (c21) (*) * 1
+Angel of the Dire Hour (plst) (*) * 1
+Angel of the Ruins (c21) (*) * 1
+Angelic Accord (plst) (*) * 1
+Angelic Arbiter (m11) (*) * 1
+Angelic Field Marshal (*) * 1
+Arcane Signet (blc) (*) * 1
+Avacyn, Angel of Hope (cmm) (*) * 1
+Baneslayer Angel (m21) (*) * 1
+Bishop of Wings (plst) (*) * 1
+Blinding Light (*) * 1
+Boon-Bringer Valkyrie (mom) (*) * 1
+Burnished Hart (dsc) (*) * 1
 Command Tower (*) * 1
-Crucible of Fire (M15)
-Crystal Quarry (*) * 1
-Cultivate
-Curiosity (*) * 1
-Cyclonic Rift (*) * 1
-Darksteel Ingot
-Deathcap Glade
-Debtors' Knell (*) * 1
-Defense of the Heart (*) * 1
-Deserted Beach
-Dragonlord Silumgar (*) * 1
-Dragonmaster Outcast
-Dragon Tempest
-Dreamroot Cascade
-Elemental Bond
-Exotic Orchard
-Faeburrow Elder (*) * 1
-Farseek (*) * 1
-Fearsome Awakening (*) * 1
-Fellwar Stone
-Force of Will (*) * 1
-Growth Spiral
-Haunted Ridge
-Haven of the Spirit Dragon (*) * 1
-Hellkite Charger (ZEN) (*) * 1
-Hellkite Tyrant (*) * 1
-Indatha Triome (*) * 1
-Karrthus, Tyrant of Jund (*) * 1
-Keiga, the Tide Star (*) * 1
-Ketria Triome (*) * 1
-Kokusho, the Evening Star (*) * 1
-Lightning Greaves (C17) (*) * 1
-Lotus Petal (*) * 1
-Malfegor (*) * 1
-Mana Confluence (*) * 1
-Mana Drain (*) * 1
-Mirari's Wake
-Mox Amber (*) * 1
-Mox Opal (*) * 1
-Mox Tantalite (*) * 1
-Niv-Mizzet, the Firemind (*) * 1
-Overgrown Farmland
-Path of Ancestry (*) * 1
-Plateau
-Prismatic Geoscope (*) * 1
-Ramos, Dragon Engine
-Raugrin Triome (*) * 1
-Rhystic Study
-Rockfall Vale
-Sarkhan the Masterless
-Sarkhan's Unsealing
-Savannah
-Savage Ventmaw (*) * 1
-Savai Triome (*) * 1
-Scrubland
-Shattered Sanctum
-Shipwreck Marsh
-Silumgar, the Drifting Death (*) * 1
-Skithiryx, the Blight Dragon (*) * 1
-Skyclave Relic (*) * 1
-Skyshroud Claim (*) * 1
-Sol Ring (*) * 1
-Spoils of Victory (*) * 1
-Stormcarved Coast
-Sundown Pass
-Swiftfoot Boots (*) * 1
-Sword of Feast and Famine (*) * 1
-Taiga
-Temur Ascendancy (*) * 1
-Teneb, the Harvester (*) * 1
-Terror of the Peaks (*) * 1
-Thrakkus the Butcher
-Three Visits (*) * 1
-Timeless Lotus
-Tropical Island
-Tundra
-Unburial Rites (*) * 1
-Underground Sea
-Utvara Hellkite (*) * 1
-Vaevictis Asmadi, the Dire (*) * 1
-Volcanic Island
-Warstorm Surge
-Wrathful Red Dragon
-Yosei, the Morning Star (*) * 1
-Zagoth Triome (*) * 1
-#CMD:The Ur-Dragon (*) * 1
+Cosmos Elixir (khm) (*) * 1
+Court of Grace (*) * 1
+Crush Contraband (scd) (*) * 1
+Darksteel Citadel (c18) (*) * 1
+Divine Sacrament (*) * 1
+Emeria Shepherd (znc) (*) * 1
+Emeria, the Sky Ruin (plst) (*) * 1
+Endless Atlas (cmm) (*) * 1
+Entreat the Angels (avr) (*) * 1
+Firemane Commando (moc) (*) * 1
+Generous Gift (*) * 1
+Ghostly Prison (*) * 1
+Herald of War (mic) (*) * 1
+Inspiring Overseer (blc) (*) * 1
+Karmic Guide (ulg) (*) * 1
+Lightning Greaves (m3c) (*) * 1
+Linvala, Keeper of Silence (*) * 1
+Luminarch Ascension (a25) (*) * 1
+Marble Diamond (*) * 1
+Mass Calcify (m15) (*) * 1
+Minas Tirith (ltr) (*) * 1
+Path to Exile (pf20) (*) * 1
+Plains (bro) (*) * 4
+Plains (woe) (*) * 4
+Plains (dsk) (*) * 4
+Plains (lci) (*) * 4
+Plains (mkm) (*) * 4
+Plains (blb) (*) * 3
+Platinum Angel (plst) (*) * 1
+Pristine Talisman (*) * 1
+Quicksilver Amulet (brr) (*) * 1
+Radiant Fountain (*) * 1
+Rebuff the Wicked (tsr) (*) * 1
+Revitalize (*) * 1
+Righteous Valkyrie (khm) (*) * 1
+Segovian Angel (plst) (*) * 1
+Sephara, Sky's Blade (cmm) (*) * 1
+Seraph Sanctuary (*) * 1
+Serra Angel (*) * 1
+Serra Ascendant (*) * 1
+Serra Avenger (*) * 1
+Serra the Benevolent (mh1) (*) * 1
+Shadowspear (plst) (*) * 1
+Sigarda's Splendor (mid) (*) * 1
+Silence (m14) (*) * 1
+Sol Ring (m3c) (*) * 1
+Solemn Simulacrum (dsc) (*) * 1
+Snow-Covered Plains (mh1) (*) * 4
+Starnheim Aspirant (j22) (*) * 1
+Steel Seraph (bro) (*) * 1
+Swiftfoot Boots (blc) (*) * 1
+Swords to Plowshares (cns) (*) * 1
+Test of Endurance (*) * 1
+The Book of Exalted Deeds (afr) (*) * 1
+Thraben Watcher (mh2) (*) * 1
+Thran Dynamo (uds) (*) * 1
+Valkyrie Harbinger (j22) (*) * 1
+Worn Powerstone (*) * 1
+Youthful Valkyrie (fdn) (*) * 1
+#CMD:Lyra Dawnbringer (dmr) (*) * 1

--- a/projects/mtg/bin/Res/ai/baka/deck148.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck148.txt
@@ -1,79 +1,24 @@
-#NAME:Tergrid Commander 2023
-#DESC:The Tergrid Commander Deck
-#DESC:Refined for Wagic by Bob
-#HINT:castpriority(commander,*)
-Necrogen Mists (MRD) *1
-Animate Dead (VMA) *1
-Mind Stone (AFC) *1
-Steel Hellkite (C17) *1
-Hedron Archive (C19) *1
-Blackblade Reforged (SS2) *1
-Swamp (2XM) *26
-Strip Mine (EXP) *1
-Archon of Cruelty (MH2) *1
-No Mercy (MP2) *1
-Whip of Erebos (THS) *1
-Plaguecrafter (C19) *1
-Smallpox (M12) *1
-Geier Reach Sanitarium (C19) *1
-Pox (ME1) *1
-Braids, Cabal Minion (EMA) *1
-Damnation (MM3) *1
-Commander's Sphere (C19) *1
-Liliana's Triumph (WAR) *1
-Dream Devourer (KHM) *1
-Night's Whisper (EMA) *1
-Grave Pact (CMD) *1
-Bojuka Bog (C19) *1
-Chain of Smog (ONS) *1
-Memory Jar (FVR) *1
-Tinybones, Trinket Thief (JMP) *1
-Sol Ring (C19) *1
-Dreadhorde Invasion (WAR) *1
-Command Beacon (PZ1) *1
-Solemn Simulacrum (TSR) *1
-Barren Moor (C19) *1
-Lotus Petal (MB1) *1
-Oppression (7ED) *1
-Shadowspear (THB) *1
-Worn Powerstone (PZ1) *1
-Arcane Signet (AFC) *1
-Lightning Greaves (AFC) *1
-Tourach, Dread Cantor (MH2) *1
-Ravenous Chupacabra (MB1) *1
-Ancient Tomb (EXP) *1
-Sword of Feast and Famine (MPS) *1
-Witch of the Moors (JMP) *1
-Thought Vessel (MB1) *1
-Urborg, Tomb of Yawgmoth (TSR) *1
-Thoughtseize (2XM) *1
-Tyrite Sanctum (KHM) *1
-Soul Shatter (ZNR) *1
-Thran Dynamo (C19) *1
-Sangromancer (MBS) *1
-Phyrexian Arena (TD0) *1
-Liliana, Dreadhorde General (WAR) *1
-Crypt Ghast (GTC) *1
-Palladium Myr (MB1) *1
-Cabal Coffers (MH2) *1
-Reliquary Tower (M13) *1
-Cabal Stronghold (DOM) *1
-Temple of the False God *1
-Charcoal Diamond *1
-Gilded Lotus *1
-Liliana of the Dark Realms *1
-Sheoldred, Whispering One *1
-Gray Merchant of Asphodel *1
-Fell Specter *1 
-Phyrexian Obliterator *1
-Hypnotic Specter *1
-Butcher of Malakir *1
-The Eldest Reborn *1
-Leaden Myr *1
-Painful Quandary *1
-Corrupt *1
-Korlash, Heir to Blackblade *1
-Syr Konrad, the Grim *1
-Megrim *1
-Mox Jet *1
-#CMD:Tergrid, God of Fright (KHM) *1
+#NAME:Kor Army
+#DESC:Deck by dr3amsnatcher
+#DESC:(tappedout.net). Refined
+#DESC:for Wagic by Bob
+Argentum Armor (*) * 2
+Armament Master (*) * 4
+Bladed Pinions (*) * 2
+Bone Saw (*) * 4
+Captain's Claws (*) * 4
+Cranial Plating (*) * 2
+Emeria, the Sky Ruin (*) * 1
+Kabira Crossroads (*) * 2
+Kitesail Apprentice (*) * 4
+Kor Duelist (*) * 4
+Oath of Gideon (*) * 2
+Plains (ZEN) (*) * 4
+Plains (BFZ) (*) * 4
+Plains (M19) (*) * 4
+Plains (ZNR) (*) * 4
+Plains (TMP) (*) * 2
+Stone Haven Outfitter (*) * 4
+Stone Haven Pilgrim (*) * 2
+Sword of Vengeance (*) * 3
+Zamriel, Seraph of Steel (*) * 2

--- a/projects/mtg/bin/Res/ai/baka/deck151.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck151.txt
@@ -1,4 +1,4 @@
-#NAME:Arcades Commander 2023
+#NAME:Arcades Commander
 #DESC:Original Deck by ashby4 (tappedout.net),
 #DESC:refined for Wagic by Bob
 #HINT:castpriority(commander,*)

--- a/projects/mtg/bin/Res/ai/baka/deck153.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck153.txt
@@ -1,4 +1,4 @@
-#NAME:Krenko Commander 2023
+#NAME:Krenko Commander
 #DESC:Original Deck by AGunWithLegs (tappedout.net),
 #DESC:refined for Wagic by Bob
 #HINT:castpriority(commander,creature,*)

--- a/projects/mtg/bin/Res/ai/baka/deck155.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck155.txt
@@ -1,4 +1,4 @@
-#NAME:Edgar Markov Commander 2023
+#NAME:Edgar Markov Commander
 #DESC:Original Deck Concept by DespairFaction (tappedout.net)
 #DESC:Designed for Wagic by Bob
 #HINT:castpriority(commander,creature,*)

--- a/projects/mtg/bin/Res/ai/baka/deck159.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck159.txt
@@ -1,4 +1,4 @@
-#NAME:Graaz Commander 2023
+#NAME:Graaz Commander
 #DESC:Deck concept thanks to punkeduard 
 #DESC:Original deck by vasarto77 (tappedout.net)
 #DESC:Refined for Wagic by Bob

--- a/projects/mtg/bin/Res/ai/baka/deck160.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck160.txt
@@ -1,4 +1,4 @@
-#NAME:Shalai-Hallar Commander 2023
+#NAME:Shalai-Hallar Commander
 #DESC:Deck concept thanks to Vitty85
 #DESC:Original deck by gabao (tappedout.net)
 #DESC:Refined for Wagic by Bob

--- a/projects/mtg/bin/Res/ai/baka/deck161.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck161.txt
@@ -1,4 +1,4 @@
-#NAME:Vial Smasher Commander 2024
+#NAME:Vial Smasher Commander
 #DESC:Original deck by GrwingErbw (tappedout.net)
 #DESC:Refined for Wagic by Bob
 #HINT:castpriority(commander,*)


### PR DESCRIPTION
Tergrid and Belbe Commander decks moved so they are unlocked sooner.  
Wipe Them Out! and Kor Army decks improved and swapped with those commander decks.  
Brand new AI commander deck based on Lyra Dawnbringer to replace weak Ur-Dragon deck which AI plays poorly.
All remaining commander decks renamed to remove date from title.