### PR TITLE
Updates to target arm64-v8a Android devices

### DIFF
--- a/projects/mtg/Android/jni/Application.mk
+++ b/projects/mtg/Android/jni/Application.mk
@@ -1,6 +1,9 @@
 APP_PROJECT_PATH := $(call my-dir)/..
 APP_CPPFLAGS += -frtti -fexceptions
-APP_ABI := armeabi-v7a
+APP_ABI := arm64-v8a
+APP_PLATFORM := android-21
+APP_CFLAGS += -march=armv8.1-a
+APP_CPPFLAGS += -D__ARM_FEATURE_LSE=1
 #APP_ABI := x86 # mainly for emulators
 APP_STL := c++_static
 APP_MODULES := libpng libjpeg main SDL


### PR DESCRIPTION
Updated Application.mk to target modern 64-bit Android (arm64-v8a).
Updated Boost library files that caused arm64-v8a build failure.
Updated JRE files that caused arm64-v8a build failure.