### PR TITLE
Updates to decks 21-30

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck21.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck21.txt
@@ -1,80 +1,25 @@
-#NAME:Burning
-#DESC:Better be prepared, 
-#DESC:to burn the midnight oil.
-#DESC:The goblin brashness
-#DESC:will make you boil.
-#DESC:And you will end 
-#DESC:burning with a low flame ...
-#2 x Bloodmark Mentor
-142062
-142062
-#4x Scuzzback Scrapper
-142052
-142052
-142052
-142052
-#4x Goblin king (10E)
-129578
-129578
-129578
-129578
-#4x Volcanic hammer
-4366
-4366
-4366
-4366
-#4x Boggart Ram-Gang  
-153970
-153970
-153970
-153970
-#4x Lightning Bolt
-1303
-1303
-1303
-1303
-#4x orcish oriflame
-1310
-1310
-1310
-1310
-#4x Raging goblin
-129688
-129688
-129688
-129688
-#4xBoartusk Liege
-147428
-147428
-147428
-147428
-#2x Siege Gang Commander
-130539
-130539
-#4x Spark elemental 
-129577
-129577
-129577
-129577
-#20x Mountain
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-129650
-
+#NAME:Goblin Gang
+#DESC:'We must not look at goblin men,
+#DESC:We must not buy their fruits:
+#DESC:Who knows upon what soil they fed
+#DESC:Their hungry thirsty roots?'
+#DESC:Christina Rossetti
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+Bloodmark Mentor (SHM) * 2
+Boartusk Liege (SHM) * 4
+Boggart Ram-Gang (SHM) * 4 
+Goblin Gang Leader (ANB) * 2
+Goblin King (10E) * 4
+Lightning Bolt (RV) * 4
+Mountain (10E) * 4
+Mountain (ANB) * 4
+Mountain (POR) * 4
+Mountain (RV) * 4
+Mountain (SHM) * 4
+Orcish Oriflamme (RV) * 4
+Raging Goblin (1OE) * 4
+Scuzzback Scrapper (SHM) * 4
+Spark Elemental (10E) * 4 
+Volcanic Hammer (POR) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck22.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck22.txt
@@ -1,83 +1,27 @@
 #NAME:Giants!
-#DESC:It's actually very hard to miss a giant.
-#DESC:You don't even have to aim your blow well.
-#DESC:The hard part
-#DESC:is to get into striking range.
-#Mogg Fanatic
-4832
-4832
-4832
-4832
-#Kithkin Greatheart 1W
-146444
-146444
-146444
-146444
-#Ballyknock Cohort
-142045
-142045
-142045
-142045
-#Sunrise Sovereign 5R
-139667
-139667
-139667
-139667
-#Axegrinder Giant
-145976
-145976
-145976
-145976
-#Blind Spot Giant
-146597
-146597
-146597
-146597
-#Borderland Behemoth
-153102
-153102
-#Oathsworn Giant {4}{W}{W} - 3/4 giant - lord creature|myinplay 0/2 vigilance other
-89012
-89012
-#Pyroclasm
-129801
-129801
-129801
-129801
-#Wall of Stone
-1325
-1325
-1325
-1325
-#Smash
-130532
-#Kitchen Finks
-141976
-141976
-141976
-#Mountain
-143626
-143626
-143626
-143627
-143627
-143627
-143631
-143631
-143631
-143623
-143623
-143623
-#Plains
-143630
-143630
-143630
-143620
-143620
-143620
-143622
-143622
-143622
-143621
-143621
-143621
+#DESC:'Who shall place
+#DESC:A limit to the giant's
+#DESC:unchained strength?'
+#DESC:William Cullen Bryant
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+#DESC:
+#DESC:Deck for Wagic by Bob
+#HINT:dontattackwith(Mogg Sentry)
+Blind-Spot Giant (LRW) * 4
+Borderland Behemoth (MOR) * 2
+Calamity Bearer (KHM) * 4
+Inferno Titan (M11) * 3
+Mogg Sentry (9ED) * 4
+Mountain (9ED) * 4
+Mountain (FDN) * 4
+Mountain (LRW) * 4
+Mountain (M11) * 4
+Mountain (RAV) * 4
+Mountain (SHM) * 4
+Mountain (TMP) * 4
+Skyraker Giant (FDN) * 4
+Stinkdrinker Daredevil (LRW) * 4
+Sunrise Sovereign (LRW) * 3
+Universal Automaton (MH1) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck23.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck23.txt
@@ -1,77 +1,29 @@
-#NAME:Selesnya
-#DESC:Do you dare arming yourself
-#DESC:against the conclave?
-#Carven Caryatid
-89048
-89048
-89048
-89048
-#Courier Hawk
-87913
-87913
-#Fists of Ironwood
-83672
-83672
-83672
-83672
-#Goliath Spider
-88959
-88959
-#Nightguard Patrol
-87975
-87975
-87975
-#Scion of the Wild
-83647
-83647
-83647
-#Selesnya Guildmage
-87988
-87988
-87988
-87988
-#Tolsimir Wolfblood
-89110
-89110
-#Veteran Armorer
-87950
-87950
-#Knight of the Skyward Eye
-175047
-175047
-#Watchwolf
-83625
-83625
-83625
-83625
-#Glorious Anthem
-129572
-129572
-129572
-129572
-#Forest
-95097
-95097
-95097
-95106
-95106
-95106
-95099
-95099
-95099
-95098
-95098
-95098
-#Plains
-95112
-95112
-95112
-95108
-95108
-95108
-95115
-95115
-95115
-95105
-95105
-95105
+#NAME:Selesnya Conclave
+#DESC:Some say that the
+#DESC:Conclave's peaceful ways
+#DESC:hide sinister coercion
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+#DESC:
+#DESC:Deck by superhiro,
+#DESC:refined by Bob
+Anthem of Champions (FDN) * 4
+Carven Caryatid (RAV) * 4
+Courier Hawk (RAV) * 2
+Faithful Watchdog (MH3) * 2
+Fists of Ironwood (RAV) * 4
+Forest (FDN) * 4
+Forest (GRN) * 4
+Forest (RAV) * 4
+Goliath Spider (RAV) * 2
+Nightguard Patrol (RAV) * 3
+Plains (FDN) * 4
+Plains (GRN) * 4
+Plains (RAV) * 4
+Scion of the Wild (RAV) * 3
+Tolsimir Wolfblood (RAV) * 2
+Vernadi Shieldmate (GRN) * 2
+Veteran Armorer (RAV) * 2
+Voice of Resurgence (MM3) * 2
+Watchwolf (RAV) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck24.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck24.txt
@@ -1,41 +1,24 @@
 #NAME:Soldiers
-#DESC:We stand together
-#DESC:Man by man
-#DESC:A marching wall of swords and shields
-#DESC:We will not stop
-#DESC:We will not bend
-#DESC:And never, never will we yield.
-Rhox Pikemaster *4
-Veteran Armorsmith *4
-Veteran Swordsmith *4
-Captain of the Watch *4
-Elite Vanguard *4
-Honor of the Pure *4
-Glorious Anthem *4
-Veteran Armorer *4
-Balefire Liege *4
-#Plains
-191382
-191382
-191382
-191382
-191382
-191382
-191395
-191395
-191395
-191395
-191395
-191395
-191396
-191396
-191396
-191396
-191396
-191396
-191385
-191385
-191385
-191385
-191385
-191385
+#DESC:We stand together, strong and true,
+#DESC:A wall of swords and shields.
+#DESC:We will not stop,
+#DESC:We will not break,
+#DESC:And never will we yield.
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+Balefire Liege (EVE) * 4
+Captain of the Watch (M10) * 4
+Elite Vanguard (M10) * 4
+Glorious Anthem (USG) * 4
+Honor of the Pure (M10) *4
+Plains (M10) * 4
+Plains (M11) * 4
+Plains (M12) * 4
+Plains (M13) * 4
+Plains (RAV) * 4
+Plains (USG) * 4
+Rhox Pikemaster (M10) * 4
+Veteran Armorer (RAV) * 4
+Veteran Armorsmith (M10) * 4
+Veteran Swordsmith (M10) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck25.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck25.txt
@@ -1,72 +1,29 @@
-#NAME:Lafiel
-#DESC:Meet the army of the influential
-#DESC:elven princess Lafiel.
-#DESC:Don't be fooled by their beauty
-#DESC:or you will lose
-#DESC:more than just your mind!
-
-#(Wagic 0.81 Deck & Avatar by Nakano)
-#v0.1 / 01.09.2009
-# Initial release
-
-#v0.2 / 02.09.2009
-# - Swamp (10E) *1 = 0
-# - Algae Gharial (ALA) *3 = 0
-# - Centaur Glade (ONS) *1 = 0
-# - Farhaven Elf (SHM) *2 = 0
-# + Forest (10E) *1 = 12
-# + Birds of Paradise (RAV) *2 = 3
-# + Civic Wayfinder (10E) *2 = 4
-# + Regal Force (EVE) *1 = 2
-# + Lorescale Coatl (ARB) *2 = 4
-
-#Mana (16)
-Forest (10E) *12
-Island (10E) *2
-Mountain (10E) *2
-
-#Green (30)
-Birds of Paradise (RAV) *3
-Blanchwood Armor (USG) *1
-Civic Wayfinder (10E) *4
-Cloudcrown Oak (LRW) *2
-Collective Unconscious (MRQ) *1
-Druid of the Anima (ALA) *2
-Elvish Piper (10E) *1
-Elvish Promenade (LRW) *1
-Howl of the Night Pack (SHM) *1
-Immaculate Magistrate (LRW) *1
-Imperious Perfect (LRW) *1
-Juvenile Gloomwidow (SHM) *1
-Llanowar Elves (10E) *1
-Lys Alana Huntmaster (LRW) *1
-Nomadic Elf (INV) *1
-Primal Rage (10E) *1
-Primordial Sage (RAV) *1
-Regal Force (EVE) *2
-Spidersilk Armor (MRQ) *1
-Thicket Basilisk (RV) *1
-Wellwisher (ONS) *2
-
-#Blue (1)
-Levitation (M10) *1
-
-#Red (6)
-Battle Squadron (MRQ) *1
-Dragon Fodder (ALA) *1
-Keldon Warlord (RV) *1
-Lava Axe (POR) *1
-Pyroclasm (ICE) *2
-
-#Black (1)
-Prowess of the Fair (LRW) *1
-
-#Multicolor (4)
-Lorescale Coatl (ARB) *4
-
-#Artifact (2)
-Obelisk of Bant (ALA) *1
-Obelisk of Grixis (ALA) *1
-
-#MANA + GREEN + BLUE + RED + BLACK + MULTI + ARTIFACT
-#16   + 30    + 1    + 6   + 1     + 4     + 2    =60
+#NAME:Dark Elves
+#DESC:The elves who wandered
+#DESC:too deeply in the forest
+#DESC:were unable to escape
+#DESC:its shadows.
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+#DESC:
+#DESC:Original deck concept by
+#DESC:Nakano, deck refined by Bob 
+Drider (AFR) * 2
+Elderfang Disciple (KHM) * 4
+Eyeblight Cullers (CMR) * 2
+Eyeblight's Ending (LRW) * 4
+Infestation Sage (FDN) * 4
+Nadier, Agent of the Duskenel (CMR) * 2
+Nadier's Nightblade (CMR) * 4
+Prowess of the Fair (LRW) * 4
+Ruthless Winnower (KHC) * 2
+Swamp (CLB) * 4
+Swamp (ELD) * 2
+Swamp (FDN) * 4
+Swamp (KHM) * 4
+Swamp (LRW) * 4
+Swamp (MKM) * 4
+Thornbow Archer (MB1) * 4
+Unscrupulous Agent (MKM) * 4
+Viconia, Drow Apostate (CLB) * 2

--- a/projects/mtg/bin/Res/ai/baka/deck26.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck26.txt
@@ -1,7 +1,6 @@
 #NAME:Atarka Commander
-#DESC:Atarka's dragons bring death
-#DESC:from the air. Can you defeat
-#DESC:her?
+#DESC:Savage and ferocious, Atarka
+#DESC:is universally feared
 #DESC: 
 #DESC:Win Wagic duels to unlock
 #DESC:more Commander opponents

--- a/projects/mtg/bin/Res/ai/baka/deck27.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck27.txt
@@ -1,84 +1,27 @@
 #NAME:Undead Infiltrator
-#DESC:You may be prepared
-#DESC:for an army of zombies
-#DESC:rising from the graves.
-#DESC:But did also expect them
-#DESC:to crawl
-#DESC:out of the sea?
-#4x Glen Elendra Liege {1}{UB}{UB}{UB} - flying lord black/blue creature +1/+1
-146743
-146743
-146743
-146743
-#4x Lord of atlantis -{U}{U} 1/1 Lord merfolk +1/+1
-1206
-1206
-1206
-1206
-#4x Lord of the Undead - {1}{B}{B} - 2/2 Lord zombie +1/+1
-129629
-129629
-129629
-129629
-#2x Sanguine Guard {1}{B}{B} - Zombie 2/2 first strike {1}{B}:regenerate
-5627
-5627
-#2x Walking dead {1}{B} - 1/1 zombie, {B}:regenerate
-1466
-1466
-#4x Oona's Gatewarden {BU} - defender flying faerie 2/1 wither
-141975
-141975
-141975
-141975
-#2x Marauding Knight, Zombie {2}{B}{B}, protection from white 2/2 +1/+1 for each plains|opponentinplay
-23053
-23053
-#2x Methatran Zombie, {1}{U}, 1/1
-22973
-22973
-#2x Inkfathom Infiltrator {UB}{UB} -  Merfolk 2/1 cantblock, unblockable
-154401
-154401
-#2x Stillmoon Cavalier {1}{WB}{WB} - Zombie knight 2/1 protection from white and black {WB}:flying {WB}:first strike
-153037
-153037
-#4x Vodalian zombie {B}{U}, zombie merfolk 2/2 protection from green
-23159
-23159
-23159
-23159
-#1x Wasp lancer {BU}{BU}{BU} 3/2 faerie flying
-153967
-#1x Deepchanel Mentor {5}{U}, 2/2 merfolk lord blue creature:unblockable
-141981
-#2x Zombie master {1}{B}{B} - 2/3 zombie lord swampwalk {B}:regenerate
-1188
-1188
-#4x Zombie outlander {B}{U} - 2/2 protection from green
-185138
-185138
-185138
-185138
-#Island
-129606
-129606
-129606
-129606
-129607
-129607
-129608
-129608
-129609
-129609
-#Swamp
-129754
-129754
-129754
-129754
-129755
-129755
-129756
-129756
-129757
-129757
+#DESC:The dead rise up from 
+#DESC:the darkest depths
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+Deepchannel Mentor (SHM) * 1
+Glen Elendra Liege (SHM) * 4
+Inkfathom Infiltrator (SHM) * 2
+Island (10E) * 4
+Island (RV) * 4
+Island (SHM) * 2
+Lord of Atlantis (RV) * 4
+Lord of the Undead (10E) * 4
+Marauding Knight (INV) * 2
+Metathran Zombie (INV) * 2
+Oona's Gatewarden (SHM) * 4
+Sanguine Guard (USG) * 2
+Swamp (10E) * 4
+Swamp (RV) * 4
+Swamp (SHM) * 2
+Underground Sea (RV) * 2
+Vodalian Zombie (INV) * 4
+Walking Dead (LEG) * 2
+Wasp Lancer (SHM) * 1
+Zombie Master (RV) * 2
+Zombie Outlander (CRX) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck28.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck28.txt
@@ -1,90 +1,28 @@
 #NAME:Depletion
-#DESC:More than one mage 
-#DESC:has been driven insane by
-#DESC:the howl of the mine,
-#DESC:Dreamborn Muse's voice,
-#DESC:and Mortivore's breath. 
-#DESC:Prepare to discover the truth
-#DESC:of the House Dimir.
-
-# (PSY) added 2x Swamp, 2x Island, 1x Psychic Drain,
-# 1x Forced Fruition, 1x Tome Scour, 1x Traumatize,
-# to bring card count to 60.
-
-#4x Animate Dead
-1143
-1143
-1143
-1143
-#2x Control Magic
-1194
-1194
-#3x Tome Scour
-191598
-191598
-191598
-#4x Glimpse the Unthinkable
-83597
-83597
-83597
-83597
-#2x Psychic Drain
-89114
-89114
-#2x Forced Fruition
-146166
-146166
-#2x Howling Mine
-129598
-129598
-#2x Memory Erosion
-175108
-175108
-#2x Mortivore
-129648
-129648
-#2x Terror
-135199
-135199
-#2x Dreamborn Muse
-135246
-135246
-#3x Traumatize
-129774
-129774
-129774
-#4x Oona's Gatewarden
-141975
-141975
-141975
-141975
-#2x Glen Elendra Liege
-146743
-146743
-#12x Swamp
-129754
-129754
-129754
-129754
-129755
-129755
-129755
-129755
-129757
-129757
-129757
-129757
-#12x Island
-129607
-129607
-129608
-129608
-129608
-129608
-129609
-129609
-129609
-129609
-129609
-129609
-
+#DESC:The cruellest fate for a  
+#DESC:spellcaster is to stand
+#DESC:helpless as your power
+#DESC:drains away.
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+Animate Dead (RV) * 4
+Control Magic (RV) * 2
+Dreamborn Muse (10E) * 2
+Forced Fruition (LRW) * 2
+Glen Elendra Liege (SHM) * 2
+Glimpse the Unthinkable (RAV) * 4
+Howling Mine (10E) * 2
+Island (10E) * 4
+Island (LRW) * 4
+Island (SHM) * 4
+Memory Erosion (ALA) * 2
+Mortivore (10E) * 2
+Oona's Gatewarden (SHM) * 4
+Swamp (10E) * 4
+Swamp (LRW) * 4
+Swamp (SHM) * 4
+Terror (10E) * 2
+Tome Scour (M10) * 4
+Traumatize (10E) * 3
+Underground Sea (RV) * 1

--- a/projects/mtg/bin/Res/ai/baka/deck29.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck29.txt
@@ -1,79 +1,23 @@
 #NAME:Vigilant Watch
-#DESC:A single soldier may sleep,
-#DESC:but the squad never does.
-#DESC:Vigilant and watchful
-#DESC:they will be ready to fight
-#DESC:as soon as you arrive.
-#4x Akrasan Squire - human soldier {W}, 1/1 exalted
-174963
-174963
-174963
-174963
-#4x Armored Ascension - {3}{W} - enchant creature - +1/+1 for each plains
-146041
-146041
-146041
-146041
-#2x Aven Squire - Bird soldier {1}{W},1/1 flying,exalted
-184992
-184992
-#4x Veteran Armorer - {1}{W} - 2/2 creature you control get +0/+1
-87950
-87950
-87950
-87950
-#4x Ballynock Cohort, Kithkin Soldier {2}{W}, 2/2, first strike +1/+1 as long as you control another white creature.
-142045
-142045
-142045
-142045
-#2x Aven Trailblazer, {2}{W} 2/*, bird soldier flying, domain (toughness = basic land you control)
-180278
-180278
-#2x Castle {3}{W} - Enchantment, untapped creature you control get +0/+2
-1334
-1334
-#4x Field Marshal {1}{W}{W} - 2/2 - other soldier get +1/+1 and first strike
-135258
-135258
-135258
-135258
-#4x Glorious Anthem {1}{W}{W} - Enchantment - creature you control get +1/++
-129572
-129572
-129572
-129572
-#2x Serra Zealot {W} - 1/1 - First strike
-5707
-5707
-#4x Mobilization {2}{W} - Soldier get vigilance - {2}{W} put a 1/1 soldier in play
-129716
-129716
-129716
-129716
-#20x plains
-1395
-1395
-1395
-1395
-129680
-129680
-129680
-129680
-129681
-129681
-129681
-129681
-129682
-129682
-129682
-129682
-129683
-129683
-129683
-129683
-#4x Soltari Foot Soldier, {W}, 1/1 shadow
-4901
-4901
-4901
-4901
+#DESC:Eyes ever wakeful,
+#DESC:eyes ever watchful.
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+Akrasan Squire (ALA) * 4
+Armored Ascension (SHM) * 4
+Aven Squire (CFX) * 2
+Aven Trailblazer (CFX) * 2
+Ballynock Cohort (SHM) * 4
+Castle (RV) * 2
+Field Marshal (10E) * 4
+Glorious Anthem (10E) * 4
+Mobilization (10E) * 4
+Plains (10E) * 4
+Plains (ALA) * 4
+Plains (RAV) * 4
+Plains (SHM) * 4
+Plains (USG) * 4
+Serra Zealot (USG) * 2
+Soltari Foot Soldier (TMP) * 4
+Veteran Armorer (RAV) * 4

--- a/projects/mtg/bin/Res/ai/baka/deck30.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck30.txt
@@ -1,31 +1,27 @@
 #NAME:Imperious Vanguard
-#DESC:An endless stream
-#DESC:of elvish warriors
-#DESC:will overwhelm you,
-#DESC:powered by an unceasing
-#DESC:supply of mana.
-#DESC:
-#DESC:Flee!
-#DESC:
-#DESC:You have no chance!
-
-# Land(s)
-Forest (M12) * 20
-Gaea's Cradle (PRM) * 1
-Pendelhaven (A25) * 1
-
-# Creature(s)
+#DESC:Elves beyond number
+#DESC:from the forest
+#DESC:without end.
+#DESC: 
+#DESC:Win matches to unlock more
+#DESC:opponents, sets and game modes
+#HINT:combo hold(Elvish Promenade|myhand)^cast(Elvish Promenade|myhand)^restriction{type(creature|mybattlefield)~morethan~1}^totalmananeeded({3}{G})
+#HINT:combo hold(Overrun|myhand)^cast(Overrun|myhand)^restriction{type(creature|mybattlefield)~morethan~2}^totalmananeeded({2}{G}{G}{G})
 Drove of Elves (SHM) * 1
 Elvish Archdruid (M10) * 4
 Elvish Hexhunter (SHM) * 4
+Elvish Promenade (LRW) * 4
 Elvish Vanguard (EMA) * 4
 Elvish Visionary (ALA) * 4
-Heedless One (PSAL) * 3
+Forest (10E) * 4
+Forest (9ED) * 4
+Forest (LRW) * 4
+Forest (M10) * 4
+Forest (M12) * 4
+Gaea's Cradle (PRM) * 1
+Heedless One (ONS) * 3
 Imperious Perfect (LRW) * 4
 Llanowar Elves (9ED) * 4
-Wellwisher (C14) * 4
-
-# Sorcery(s)
-Elvish Promenade (LRW) * 4
 Overrun (10E) * 2
-
+Pendelhaven (A25) * 1
+Wellwisher (C14) * 4


### PR DESCRIPTION
Decks 21-30 reformatted and new flavor texts added.  Cards swapped in or out of decks 21 and 23 to improve AI decisions; land ratios increased in decks 27 and 28 to improve AI performance; added hints to deck 30 to prevent AI wasting strong cards; decks 22 and 25 were quite poor and are now replaced with new decks on similar or identical themes