### PR TITLE
Updates to decks 71-80

### DIFF
--- a/projects/mtg/bin/Res/ai/baka/deck71.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck71.txt
@@ -1,17 +1,21 @@
 #NAME:Thistlestings
-#DESC:Meet a more mystical tribe
-#DESC:of Kithkin. Will you allow
-#DESC:them to confuse you?
-Wings of Aesthir (ICE)       * 4 #
-Wings of Hope (INV)          * 4 #
-Plains (INV)                 *12 #
-Island (INV)                 *12 #
-Iridescent Angel (ODY)       * 2 #
-Zealous Guardian (SHM)       * 4 #
-Somnomancer (SHM)            * 2 #
-Thistledown Liege (SHM)      * 4 #
-Thistledown Duo (SHM)        * 4 #
-Plumeveil (SHM)              * 2 #
-Ethercaste Knight (ARB)      * 4 #
-Wall of Denial (ARB)         * 2 #
-Esper Cormorants (CFX)       * 4 #
+#DESC:A dozen stings is more
+#DESC:painful than one mighty
+#DESC:blow
+Esper Cormorants (CFX) * 4 #
+Ethercaste Knight (ARB) * 4 #
+Iridescent Angel (ODY) * 2 #
+Island (ODY) * 4 #
+Island (INV) * 4 #
+Island (SHM) * 4 #
+Plains (ODY) * 4 #
+Plains (INV) * 4 #
+Plains (SHM) * 4 #
+Plumeveil (SHM) * 2 #
+Somnomancer (SHM) * 2 #
+Thistledown Duo (SHM) * 4 #
+Thistledown Liege (SHM) * 4 #
+Wall of Denial (ARB) * 2 #
+Wings of Aesthir (ICE) * 4 #
+Wings of Hope (INV) * 4 #
+Zealous Guardian (SHM) * 4 #

--- a/projects/mtg/bin/Res/ai/baka/deck72.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck72.txt
@@ -1,16 +1,18 @@
 #NAME:Creaky Wood
-#DESC:"Death has always been
-#DESC: a part of nature.
-#DESC: We embrace it
-#DESC: to enhance our power."
-Llanowar Dead (APC)          * 4 #
-Ebony Treefolk (APC)         * 4 #
-Putrefy (RAV)                * 4 #
-Vulturous Zombie (RAV)       * 4 #
-Odious Trow (EVE)            * 4 #
-Stalker Hag (EVE)            * 4 #
-Noxious Hatchling (EVE)      * 4 #
-Creakwood Liege (EVE)        * 4 #
-Rendclaw Trow (EVE)          * 4 #
-Forest (ALA)                 *12 #
-Swamp (ALA)                  *12 #
+#DESC:Death has always been
+#DESC:a part of nature.
+Creakwood Liege (EVE) * 4 #
+Dreg Mangler (RTR) * 4 #
+Forest (ALA) * 4 #
+Forest (9ED) * 4 #
+Forest (RAV) * 4 #
+Llanowar Dead (APC) * 4 #
+Noxious Hatchling (EVE) * 4 #
+Odious Trow (EVE) * 4 #
+Putrefy (RAV) * 4 #
+Rendclaw Trow (EVE) * 4 #
+Stalker Hag (EVE) * 4 #
+Swamp (ALA) * 4 #
+Swamp (9ED) * 4 #
+Swamp (RAV) * 4 #
+Vulturous Zombie (RAV) * 4 #

--- a/projects/mtg/bin/Res/ai/baka/deck73.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck73.txt
@@ -1,18 +1,22 @@
 #NAME:Saproling Surge
-#DESC:A wiggling, squirming mass
-#DESC:of fungal matter
-#DESC:will overgrow your army.
-Verdant Force (TMP)          * 2 #
-Gaea's Cradle (USG)          * 2 #
-Spontaneous Generation (MRQ) * 2 #
-Nemata, Grove Guardian (PLS) * 1 #
-Fists of Ironwood (RAV)      * 4 #
-Forest (RAV)                 *15 #
-Swamp (RAV)                  * 7 #
-Verdant Embrace (TSP)        * 4 #
-Sprout (TSP)                 * 4 #
-Gaea's Anthem (PLC)          * 4 #
-Creakwood Liege (EVE)        * 4 #
-Necrogenesis (ALA)           * 4 #
-Morbid Bloom (ARB)           * 3 #
-Tukatongue Thallid (CFX)     * 4 #
+#DESC:The tenacity of new life
+#DESC:is remarkable, but left
+#DESC:unchecked it is terrifying
+#HINT:combo hold(Fungal Sprouting|myhand)^cast(Fungal Sprouting|myhand)^restriction{type(creature|mybattlefield)~morethan~1}^totalmananeeded({3}{G})
+Creakwood Liege (EVE) * 4 #
+Fists of Ironwood (RAV) * 4 #
+Forest (ALA) * 4 #
+Forest (TSP) * 4 #
+Forest (RAV) * 4 #
+Forest (TMP) * 4 #
+Forest (M13) * 4 #
+Fungal Sprouting (M13) * 3 #
+Gaea's Anthem (PLC) * 4 #
+Gaea's Cradle (USG) * 2 #
+Overgrown Armasaur (RIX) * 2 #
+Saproling Migration (DOM) * 4 #
+Shroofus Sproutsire (J25) * 3 #
+Sprout (TSP) * 4 #
+Tendershoot Dryad (RIX) * 4 #
+Tukatongue Thallid (CFX) * 4 #
+Verdant Embrace (TSP) * 2 #

--- a/projects/mtg/bin/Res/ai/baka/deck74.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck74.txt
@@ -1,27 +1,28 @@
 #NAME:Boar's Tusks
-#DESC:Prepare to meet an army
-#DESC:of mighty creatures
-#DESC:harnessing the power
-#DESC:of fire and nature alike.
-Sunastian Falconer (LEG)     * 1 #
-Rock Basilisk (MIR)          * 1 #
-Viashivan Dragon (VIS)       * 1 #
-Gaea's Cradle (USG)          * 2 #
-Yavimaya Barbarian (INV)     * 2 #
-Yavimaya Kavu (INV)          * 4 #
-Rumbling Slum (GPT)          * 1 #
-Borborygmos (GPT)            * 1 #
-Streetbreaker Wurm (GPT)     * 1 #
+#DESC:Imagine an army with the
+#DESC:solidity of earth and the
+#DESC:ferocity of flame
+Boartusk Liege (SHM) * 4 #
+Boggart Ram-Gang (SHM) * 4 #
+Borborygmos (GPT) * 1 #
+Forest (INV) * 4 #
+Forest (SHM) * 4 #
+Forest (TSP) * 4 #
+Gaea's Cradle (USG) * 2 #
+Mountain (INV) * 4 #
+Mountain (SHM) * 4 #
+Mountain (TSP) * 4 #
+Nacatl Outlander (CFX) * 2 #
+Rhox Brute (ARB) * 1 #
+Rip-Clan Crasher (ALA) * 2 #
+Rock Basilisk (MIR) * 1 #
+Rumbling Slum (GPT) * 1 #
+Savage Ventmaw (DTK) * 1 #
+Scuzzback Marauders (SHM) * 1 #
+Scuzzback Scrapper (SHM) * 4 #
 Stonebrow, Krosan Hero (TSP) * 1 #
-Loamdragger Giant (SHM)      * 1 #
-Tattermunge Maniac (SHM)     * 3 #
-Scuzzback Scrapper (SHM)     * 3 #
-Boartusk Liege (SHM)         * 4 #
-Scuzzback Marauders (SHM)    * 1 #
-Tattermunge Duo (SHM)        * 2 #
-Boggart Ram-Gang (SHM)       * 4 #
-Forest (SHM)                 *11 #
-Mountain (SHM)               *11 #
-Rip-Clan Crasher (ALA)       * 2 #
-Nacatl Outlander (CFX)       * 2 #
-Rhox Brute (ARB)             * 1 #
+Streetbreaker Wurm (GPT) * 1 #
+Tattermunge Duo (SHM) * 2 #
+Tattermunge Maniac (SHM) * 3 #
+Yavimaya Barbarian (INV) * 2 #
+Yavimaya Kavu (INV) * 3 #

--- a/projects/mtg/bin/Res/ai/baka/deck75.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck75.txt
@@ -1,16 +1,23 @@
-#NAME:Air Sea Battle
-#DESC:Meet the darker side
-#DESC:of fairies
-#DESC:and merfolk.
-Sleeper's Robe (INV)         * 4 #
+#NAME:Pitch Darkness
+#DESC:In the storm clouds and
+#DESC:the inky depths, the 
+#DESC:enemy strikes without
+#DESC:warning.
+#HINT:alwaysattackwith(Inkfathom Infiltrator)
+Glen Elendra Liege (SHM) * 4 #
+Gravelgill Axeshark (SHM) * 2 #
+Gravelgill Duo (SHM) * 3 #
+Helm of the Ghastlord (SHM) * 2 #
+Inkfathom Infiltrator (SHM) * 4 #
+Island (M10) * 4 #
+Island (M11) * 4 #
+Island (SHM) * 4 #
+Nightveil Predator (GRN) * 3
+Oona's Gatewarden (SHM) * 4 #
 Shadowmage Infiltrator (ODY) * 3 #
-Gravelgill Axeshark (SHM)    * 3 #
-Oona's Gatewarden (SHM)      * 4 #
-Glen Elendra Liege (SHM)     * 4 #
-Gravelgill Duo (SHM)         * 3 #
-Wasp Lancer (SHM)            * 3 #
-Scarscale Ritual (SHM)       * 4 #
-Inkfathom Infiltrator (SHM)  * 4 #
-Tidehollow Strix (ALA)       * 4 #
-Swamp (M10)                  *12 #
-Island (M10)                 *12 #
+Sleeper's Robe (INV) * 4 #
+Swamp (M10) * 4 #
+Swamp (M11) * 4 #
+Swamp (SHM) * 4 #
+Tidehollow Strix (ALA) * 4 #
+Wasp Lancer (SHM) * 3 #

--- a/projects/mtg/bin/Res/ai/baka/deck76.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck76.txt
@@ -1,26 +1,25 @@
 #NAME:The Memorial
-#DESC:What will you do
-#DESC:when you are facing
-#DESC:an army of super-beings?
-#DESC:
 #DESC:Worshipping the Memorial
-#DESC:gives them powers
-#DESC:beyond comprehension.
-Pendelhaven (LEG)            * 1 #
-Urborg (LEG)                 * 1 #
-Fyndhorn Elves (ICE)         * 4 #
+#DESC:grants powers beyond
+#DESC:comprehension.
+#HINT:combo hold(Elvish Promenade|myhand)^cast(Elvish Promenade|myhand)^restriction{type(creature[Elf]|mybattlefield)~morethan~2}^totalmananeeded({3}{G})
+Akroma's Memorial (FUT) * 4 #
+Ant Queen (M10) * 3 #
+Bitterblossom (MOR) * 4 #
+Citanul Hierophants (USG) * 1 #
 Eladamri, Lord of Leaves (TMP) * 1 #
-Citanul Hierophants (USG)    * 1 #
-Priest of Titania (USG)      * 4 #
-Gaea's Cradle (USG)          * 1 #
-Wirewood Lodge (ONS)         * 1 #
-Wellwisher (ONS)             * 4 #
-Akroma's Memorial (FUT)      * 4 #
-Elvish Promenade (LRW)       * 3 #
-Imperious Perfect (LRW)      * 4 #
-Bitterblossom (MOR)          * 4 #
-Llanowar Elves (M10)         * 4 #
-Ant Queen (M10)              * 3 #
-Elvish Archdruid (M10)       * 4 #
-Forest (ZEN)                 *12 #
-Swamp (ZEN)                  * 4 #
+Elvish Archdruid (M10) * 4 #
+Elvish Promenade (LRW) * 3 #
+Forest (LRW) * 4 #
+Forest (M10) * 4 #
+Forest (M11) * 1 #
+Forest (ZEN) * 4 #
+Fyndhorn Elves (ICE) * 4 #
+Gaea's Cradle (USG) * 1 #
+Imperious Perfect (LRW) * 4 #
+Llanowar Elves (M10) * 4 #
+Pendelhaven (LEG) * 1 #
+Priest of Titania (USG) * 4 #
+Swamp (M10) * 1 #
+Swamp (ZEN) * 4 #
+Wellwisher (ONS) * 4 #

--- a/projects/mtg/bin/Res/ai/baka/deck77.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck77.txt
@@ -1,24 +1,22 @@
 #NAME:Bleeding Megrim
-#DESC:And it will tell you how
-#DESC:the day after a triumph 
-#DESC:is as hollow as the
-#DESC:day after a tragedy.
-Seal of Fire (DIS)           * 4 #
-Megrim (10E)                 * 4 #
-Wheel of Fortune (RV)    * 1 #
-Terminate (ARB)              * 3 #
-Kederekt Parasite (CFX)      * 4 #
-Hypnotic Specter (M10)       * 4 #
-Lightning Bolt (M10)         * 4 #
-Howling Mine (M10)           * 4 #
-Wall of Fire (M10)           * 4 #
-Pyroclasm (M10)              * 2 #
-Swamp (ZEN)                  * 2 #
-Swamp (ZEN)                  * 3 #
-Mountain (ZEN)               * 3 #
-Mountain (ZEN)               * 3 #
-Mountain (ZEN)               * 3 #
-Mountain (ZEN)               * 3 #
-Swamp (ZEN)                  * 2 #
-Swamp (ZEN)                  * 3 #
-Burning Inquiry (M10)        * 4 #
+#DESC:A cruel inquiry after 
+#DESC:an unwilling sacrifice
+#DESC:worsens the pain of loss.
+#HINT:combo hold(Burning Inquiry|myhand)^cast(Burning Inquiry|myhand)^restriction{type(Megrim|mybattlefield)~morethan~0}^totalmananeeded({R})
+#HINT:combo hold(Wheel of Fortune|myhand)^cast(Wheel of Fortune|myhand)^restriction{type(Megrim|mybattlefield)~morethan~0}^totalmananeeded({2}{R})
+Aether Membrane (PLC) * 4 #
+Burning Inquiry (M10) * 4 #
+Fell (BLB) * 4 #
+Howling Mine (M10) * 4 #
+Hypnotic Specter (M10) * 4 #
+Kederekt Parasite (CFX) * 4 #
+Lightning Bolt (M10) * 4 #
+Megrim (10E) * 4 #
+Mountain (M10) * 4 #
+Mountain (RV) * 3 #
+Mountain (ZEN) * 4 #
+Swamp (M10) * 4 #
+Swamp (RV) * 3 #
+Swamp (ZEN) * 4 #
+Terminate (ARB) * 4 #
+Wheel of Fortune (RV) * 2 #

--- a/projects/mtg/bin/Res/ai/baka/deck78.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck78.txt
@@ -1,18 +1,23 @@
 #NAME:White Blades
-#DESC:Meet a complete army
-#DESC:of soldiers, knights, and guards.
-#DESC:
-#DESC:Can you stop them,
-#DESC:or will you just stand aside
-#DESC:and watch in awe?
-Steppe Lynx (ZEN)            * 3 #
-Akrasan Squire (ALA)         * 4 #
-Day of Judgment (ZEN)        * 3 #
-White Knight (M10)           * 4 #
-Elite Vanguard (M10)         * 4 #
-Pacifism (M10)               * 4 #
-Honor of the Pure (M10)      * 4 #
-Captain of the Watch (M10)   * 4 #
-Kazandu Blademaster (ZEN)    * 4 #
-Plains (ZEN)                 *23 #
-Conqueror's Pledge (ZEN)     * 3 #
+#DESC:When their burnished blades
+#DESC:appear on the horizon, you
+#DESC:will know that salvation
+#DESC:is at hand.
+Arrest (SOM) * 2 #
+Boros Elite (GTC) * 2 #
+Captain of the Watch (M10) * 4 #
+Champion of the Parish (ISD) * 4 #
+Conqueror's Pledge (ZEN) * 3 #
+Elite Inquisitor (ISD) * 3 #
+Elite Vanguard (M10) * 4 #
+Hanweir Militia Captain (SOI) * 2 #
+Haazda Marshal (GRN) * 2 #
+Honor of the Pure (M10) * 4 #
+Pacifism (M10) * 4 #
+Plains (ALA) * 4 #
+Plains (ISD) * 4 #
+Plains (M10) * 4 #
+Plains (M11) * 4 #
+Plains (SOM) * 3 #
+Plains (ZEN) * 4 #
+Raise the Alarm (M15) * 3 #

--- a/projects/mtg/bin/Res/ai/baka/deck79.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck79.txt
@@ -1,17 +1,22 @@
 #NAME:Malakir Seeker
-#DESC:"The cattle has arrived.
-#DESC: Time to feed ..."
-Bad Moon (RV)                * 4 #
-Terror (RV)                  * 3 #
-Swamp (RV)                   *16 #
-Vampire Hounds (EXO)         * 2 #
-Piranha Marsh (ZEN)          * 4 #
-Marsh Casualties (ZEN)       * 4 #
-Vampire's Bite (ZEN)         * 4 #
-Disfigure (ZEN)              * 4 #
-Blood Seeker (ZEN)           * 4 #
-Vampire Nighthawk (ZEN)      * 4 #
-Malakir Bloodwitch (ZEN)     * 2 #
-Sign in Blood (M10)          * 3 #
-Child of Night (M10)         * 4 #
+#DESC:The last true refuge of
+#DESC:vampires is a lethal place
+#DESC:for the unwary.
+Bad Moon (RV) * 4 #
+Blood Seeker (ZEN) * 4 #
+Child of Night (M10) * 4 #
+Cordial Vampire (MH1) * 2 #
+Feast of Blood (ZEN) * 2 #
+Gift of Fangs (VOW) * 4 #
+Guul Draz Vampire (ZEN) * 4 #
+Malakir Bloodwitch (ZEN) * 2 #
 Ob Nixilis, the Fallen (ZEN) * 2 #
+Piranha Marsh (ZEN) * 2 #
+Swamp (ISD) * 4 #
+Swamp (M10) * 4 #
+Swamp (M11) * 4 #
+Swamp (RV) * 4 #
+Swamp (ZEN) * 4 #
+Terror (RV) * 2 #
+Vampire Nighthawk (ZEN) * 4 #
+Victim of Night (ISD) * 4 #

--- a/projects/mtg/bin/Res/ai/baka/deck80.txt
+++ b/projects/mtg/bin/Res/ai/baka/deck80.txt
@@ -1,18 +1,24 @@
 #NAME:Destroy
-#DESC:I will destroy your lands
-#DESC:and then your army
-#DESC:and then you.
-Black Vise (RV)              * 4 #
-Black Knight (RV)            * 2 #
-Dark Ritual (RV)             * 4 #
-Lightning Bolt (RV)          * 4 #
-Stone Rain (RV)              * 4 #
-Wheel of Fortune (RV)        * 1 #
-Swamp (RV)                   * 11 #
-Mountain (RV)                * 11 #
-Slith Firewalker (MRD)       * 4 #
-Rain of Tears (10E)          * 4 #
-Fulminator Mage (SHM)        * 3 #
-Terminate (ARB)              * 4 #
-Vampire Nighthawk (ZEN)      * 2 #
-Sign in Blood (M10)          * 2 #
+#DESC:'Is it in destroying and pulling
+#DESC:down that skill is displayed?
+#DESC:The shallowest understanding is
+#DESC:more equal to that task.'
+#DESC:Edmund Burke
+Aether Membrane (PLC) * 2 #
+Black Vise (RV) * 4 #
+Craterize (M13) * 4 #
+Deus of Calamity (SHM) * 1 #
+Forest (10E) * 4 #
+Forest (M10) * 4 #
+Forest (M13) * 1 #
+Forest (RV) * 4 #
+Ice Storm (LEA) * 4 #
+Lightning Bolt (RV) * 4 #
+Mountain (10E) * 4 #
+Mountain (M10) * 4 #
+Mountain (RV) * 4 #
+Slith Firewalker (MRD) * 2 #
+Stone Rain (RV) * 4 #
+Terravore (ODY) * 4 #
+Thresher Beast (PCY) * 2 #
+Winter's Grasp (TMP) * 4 #


### PR DESCRIPTION
Decks 71-80 reformatted.  Minor changes to most decks: adding hints to improve strategy; swapping out cards AI plays poorly for other on-theme options; adjusting land ratios to better fit average CMCs.  Deck 75 renamed.  Deck 80 rebuilt to include clearer wincon, but maintaining same theme and strategy.