### PR TITLE
Revive the Linux SDL build: port to SDL2, fix platform bugs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,87 @@
+# Building Wagic
+
+Wagic targets several platforms from one codebase. The game logic lives in
+`projects/mtg/`, the engine layer in `JGE/`. Pick your platform below.
+
+## Linux (SDL2) — primary desktop dev build
+
+Requires the SDL2 port of the JGE layer (merged 2026; if your checkout
+predates it, the Linux/SDL path targeted an unreleased SDL 1.3 snapshot and
+did not compile).
+
+Dependencies (Arch): `qt6-base sdl2-compat boost libjpeg-turbo libpng giflib glu zlib`
+Dependencies (Debian/Ubuntu): `qt6-base-dev libsdl2-dev libboost-dev libboost-thread-dev libjpeg-dev libpng-dev libgif-dev libglu1-mesa-dev zlib1g-dev`
+
+```bash
+cd projects/mtg
+qmake6 wagic-SDL.pro CONFIG+=debug -o Makefile.sdl
+make -f Makefile.sdl -j$(nproc)
+cd bin && ./wagic     # must run from bin/ (needs ./Res)
+```
+
+Notes:
+- Always pass `-o Makefile.sdl`: a bare `qmake6` overwrites the tracked
+  `projects/mtg/Makefile` (the PSP makefile).
+- The C++ standard is pinned to `gnu++14` in `wagic-SDL.pro` (the code still
+  uses `random_shuffle`/`bind2nd`/`ptr_fun`, removed in C++17).
+- Release build: drop `CONFIG+=debug`. Debug builds include the test suite.
+
+### Running the test suite (debug builds)
+
+```bash
+cd projects/mtg/bin
+WAGIC_TESTSUITE=1 ./wagic        # runs headlessly, exits 0/1 with a summary
+```
+
+Results land in `User/test/results.html`. To run a subset, edit
+`Res/test/_tests.txt` (restore it afterwards — it is a tracked file).
+
+## Linux (Qt)
+
+An alternative Qt front end exists:
+
+```bash
+cd projects/mtg
+qmake -qt=qt5 wagic-qt.pro
+make -j$(nproc)
+```
+
+Needs `qt5-qmake qtbase5-dev qtdeclarative5-dev qttools5-dev
+qtmultimedia5-dev libqt5opengl5-dev` (Debian names). This is the
+front end the old Travis CI built.
+
+## Windows
+
+Open `projects/mtg/mtg_vs2010.sln` in Visual Studio (the solution has been
+imported into newer VS versions; AppVeyor built it this way). Build the
+`wagic` project; run with the working directory set to a folder containing
+`Res/`.
+
+## Android
+
+The in-tree Android project (`projects/mtg/Android/`) is the legacy
+ant + NDK layout; the old CI used android-ndk-r22 with `ant`. Expect to
+update SDK/NDK paths in `local.properties`. A modernization to Gradle is an
+open task.
+
+## PSP
+
+The original target. Needs the PSP toolchain (`PSPDEV`/`PSPSDK` env vars,
+pspsdk 0.11.x):
+
+```bash
+cd projects/mtg
+make            # uses the tracked PSP Makefile
+```
+
+## PS Vita
+
+A community port by Brendonm17 (github.com/Brendonm17/wagic-vita) builds
+with VitaSDK + vitaGL via CMake. Forks that have merged it carry a
+`BUILD_VITA.md` with the full recipe, including the required vitaGL version
+pin.
+
+## macOS / iOS
+
+Historical Xcode projects exist under `projects/mtg/` but have not been
+exercised recently; expect bitrot. Contributions welcome.

--- a/JGE/include/DebugRoutines.h
+++ b/JGE/include/DebugRoutines.h
@@ -56,6 +56,13 @@ std::string ToHex(T* pointer)
 	stream << inString;					    \
 	__android_log_write(ANDROID_LOG_DEBUG, "Wagic", stream.str().c_str());\
 }
+#elif defined (LINUX)
+#define DebugTrace(inString)								\
+{															\
+	std::ostringstream stream;								\
+	stream << inString << std::endl;					    \
+	std::cerr << stream.str();  \
+}
 #else
 #define DebugTrace(inString)								\
 {															\

--- a/JGE/include/Downloader.h
+++ b/JGE/include/Downloader.h
@@ -39,11 +39,9 @@ class DownloadRequest
     Q_OBJECT
 
 private slots:
-#endif
     void fileDownloaded();
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
 
-#ifdef QT_CONFIG
 signals:
     void percentChanged(int percent);
     void statusChanged(int);

--- a/JGE/include/JGE.h
+++ b/JGE/include/JGE.h
@@ -31,7 +31,7 @@ typedef u32 LocalKeySym;
 
 #elif defined(SDL_CONFIG)
 #include <SDL.h>
-typedef SDLKey LocalKeySym;
+typedef SDL_Keycode LocalKeySym;
 #define LOCAL_KEY_NONE SDLK_UNKNOWN
 
 #elif defined(WIN32)

--- a/JGE/src/Downloader.cpp
+++ b/JGE/src/Downloader.cpp
@@ -54,6 +54,7 @@ void DownloadRequest::startGet()
 #endif
 }
 
+#ifdef QT_CONFIG
 void DownloadRequest::fileDownloaded()
 {
     do {
@@ -119,6 +120,7 @@ void DownloadRequest::downloadProgress(qint64 bytesReceived, qint64 bytesTotal)
         percent = (bytesReceived/bytesTotal)*100;
     emit percentChanged(percent);
 }
+#endif // QT_CONFIG
 
 Downloader* Downloader::mInstance = 0;
 

--- a/JGE/src/SDLmain.cpp
+++ b/JGE/src/SDLmain.cpp
@@ -108,7 +108,7 @@ class SdlApp
 public: /* For easy interfacing with JGE static functions */
     bool            Running;
     SDL_Window*     window;
-    SDL_Surface*    Surf_Display;
+    SDL_GLContext   glContext;
     SDL_Rect        viewPort;
     Uint32          lastMouseUpTime;
     Uint32          lastFingerDownTime;
@@ -121,7 +121,7 @@ public: /* For easy interfacing with JGE static functions */
     int mMouseDownY;
 
 public:
-    SdlApp() : Surf_Display(NULL), window(NULL), lastMouseUpTime(0), lastFingerDownTime(0), Running(true), mMouseDownX(0), mMouseDownY(0)
+    SdlApp() : glContext(NULL), window(NULL), lastMouseUpTime(0), lastFingerDownTime(0), Running(true), mMouseDownX(0), mMouseDownY(0)
     {
     }
 
@@ -291,7 +291,10 @@ public:
 
     void OnCleanup()
     {
-        SDL_FreeSurface(Surf_Display);
+        if (glContext)
+            SDL_GL_DeleteContext(glContext);
+        if (window)
+            SDL_DestroyWindow(window);
         SDL_Quit();
     }
 };
@@ -459,7 +462,7 @@ void SdlApp::OnUpdate()
 	if(g_engine)
 		g_engine->Render();
 
-	SDL_GL_SwapBuffers();
+	SDL_GL_SwapWindow(window);
 }
 
 void SdlApp::OnKeyPressed(const SDL_KeyboardEvent& event)
@@ -653,12 +656,13 @@ bool SdlApp::OnInit()
 		return false;
 	}
 
-	const SDL_VideoInfo *pVideoInfo = SDL_GetVideoInfo();
-	DebugTrace("Video Display : h " << pVideoInfo->current_h << ", w " << pVideoInfo->current_w);
+	SDL_DisplayMode displayMode;
+	SDL_GetCurrentDisplayMode(0, &displayMode);
+	DebugTrace("Video Display : h " << displayMode.h << ", w " << displayMode.w);
 
 #if (defined ANDROID) || (defined IOS)
-	window_w = pVideoInfo->current_w;
-	window_h = pVideoInfo->current_h;
+	window_w = displayMode.w;
+	window_h = displayMode.h;
 #else
 	window_w = ACTUAL_SCREEN_WIDTH;
 	window_h = ACTUAL_SCREEN_HEIGHT;
@@ -683,17 +687,25 @@ bool SdlApp::OnInit()
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 
-	if((Surf_Display = SDL_SetVideoMode(window_w, window_h, 32,
+	window = SDL_CreateWindow(g_launcher->GetName(),
+		SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+		window_w, window_h,
 #ifdef ANDROID
-		SDL_OPENGL | SDL_FULLSCREEN | SDL_WINDOW_BORDERLESS)) == NULL)
-	{
+		SDL_WINDOW_OPENGL | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_BORDERLESS);
 #else
-		SDL_OPENGL | SDL_RESIZABLE )) == NULL)
-	{
+		SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
+	if (!window)
+	{
 		return false;
 	}
-	SDL_WM_SetCaption(g_launcher->GetName(), "");
+
+	glContext = SDL_GL_CreateContext(window);
+	if (!glContext)
+	{
+		return false;
+	}
+	SDL_GL_SetSwapInterval(1);
 
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);		// Black Background (yes that's the way fuckers)
 #if (defined GL_ES_VERSION_2_0) || (defined GL_VERSION_2_0)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Chat with the community on the [**Wagic - MTG Game** Discord](https://discord.co
 
 Developer information from the [Wagic Wiki](https://github.com/WagicProject/wagic/wiki) is also included in the [wagic/docs/](docs) folder.
 
+Compilation instructions for all platforms are in [BUILDING.md](BUILDING.md).
+
 
 ### Sample round play-through video
 

--- a/projects/mtg/src/GameOptions.cpp
+++ b/projects/mtg/src/GameOptions.cpp
@@ -1212,10 +1212,11 @@ bool GameOptionKeyBindings::read(string input)
         iss.get(*(s.rdbuf()), ',');
         iss.get();
 
-        LocalKeySym local = 0;
+        u32 localRaw = 0;
         char sep = 0;
         u32 button = 0;
-        s >> local >> sep >> button;
+        s >> localRaw >> sep >> button;
+        LocalKeySym local = static_cast<LocalKeySym>(localRaw);
 
         if (':' != sep)
             return false;

--- a/projects/mtg/wagic-SDL.pro
+++ b/projects/mtg/wagic-SDL.pro
@@ -11,23 +11,28 @@ QT -= core gui opengl network declarative
 
 #unix|windows:QMAKE_CXXFLAGS += -std=c++11
 
-INCLUDEPATH += ../../JGE/Dependencies/SDL/include
+windows:INCLUDEPATH += ../../JGE/Dependencies/SDL/include
 unix:INCLUDEPATH += /usr/include/GL
-unix:INCLUDEPATH += /usr/local/include/SDL
+unix:INCLUDEPATH += /usr/include/SDL2
+unix:QMAKE_CXXFLAGS += -std=gnu++14
 OBJECTS_DIR = objs
 MOC_DIR = objs
 DESTDIR = bin
 
-macx|unix:LIBS += -lz -lboost_thread-mt
-unix:LIBS += -ljpeg -lgif -lpng12 -L/usr/local/lib -lGL -lGLU -lSDL
+macx|unix:LIBS += -lz -lboost_thread
+unix:LIBS += -ljpeg -lgif -lpng -L/usr/local/lib -lGL -lGLU -lSDL2
 windows:LIBS += -L../../JGE/Dependencies/lib -L../../Boost/lib -llibjpeg-static-mt-debug -lgiflib -llibpng -lfmodvc
 
-CONFIG(debug, debug|release):SOURCES += src/TestSuiteAI.cpp
+# TestSuiteAI.cpp is already in wagic.pri's SOURCES; adding it here double-links
 
 # JGE, could probably be moved outside
 SOURCES += \
         ../../JGE/src/SDLmain.cpp\
         ../../JGE/src/JMD2Model.cpp
+
+unix:SOURCES += \
+        ../../JGE/src/pc/JGfx.cpp\
+        ../../JGE/src/pc/JSfx.cpp
 
 windows{
 

--- a/projects/mtg/wagic.pri
+++ b/projects/mtg/wagic.pri
@@ -8,7 +8,8 @@ unix:!*macx*:QMAKE_CXXFLAGS += -Wno-unused-but-set-parameter
 unix:!*macx*:QMAKE_CXXFLAGS += -Wno-unused-but-set-variable
 unix|*macx*:QMAKE_CXXFLAGS += -Wno-unused-value
 unix:!*macx*:QMAKE_CXXFLAGS += -Wno-unused-local-typedefs
-unix:!*macx*:!maemo5:!symbian:QMAKE_CXXFLAGS += -Werror
+# -Werror disabled: GCC 15 warning set is fatal on this 2010-era codebase
+#unix:!*macx*:!maemo5:!symbian:QMAKE_CXXFLAGS += -Werror
 unix|macx:QMAKE_CXXFLAGS += -Wno-nonnull-compare
 
 windows:DEFINES += _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

The Linux SDL build (`projects/mtg/wagic-SDL.pro`) has bitrotted: it targets the vendored SDL 1.3 dev snapshot (`JGE/Dependencies/SDL`), which no Linux distribution ships, and links against `libpng12` / `boost_thread-mt` library names that no longer exist. On a current distro (tested: Arch, GCC 15, Qt6 qmake) it cannot compile at all.

This PR makes the Linux build work again with system SDL2, without touching other platforms:

**Platform bug fixes** (first commit — these are latent bugs on any platform):
- `DebugRoutines.h`: Linux debug builds fell through to the Windows-only `OutputDebugStringA` branch, so Linux+SDL+`_DEBUG` never compiled. Added a proper `LINUX` branch using `std::cerr`.
- `Downloader`: the `QT_CONFIG` guards around Qt-only slot methods were incomplete, breaking any non-Qt build that compiles `Downloader.cpp`.
- `GameOptions`: the key-binding parser streamed directly into the `SDLKey` enum, which is not valid C++; now parses through `u32` and casts.

**SDL2 port** (second commit): `SDLmain.cpp` already used mostly SDL2-era APIs (window events, touch, mouse wheel). The remaining 1.2-only calls are replaced with their SDL2 equivalents (`SDL_SetVideoMode`/`SDL_GetVideoInfo`/`SDL_WM_SetCaption`/`SDL_GL_SwapBuffers` → `SDL_CreateWindow`/`SDL_GetCurrentDisplayMode`/`SDL_GL_CreateContext`/`SDL_GL_SwapWindow`), and `LocalKeySym` becomes `SDL_Keycode`. All replacement APIs exist with identical signatures in the vendored SDL 1.3 headers, so the Android build (which compiles the same file against the vendored copy) is unaffected — verified symbol-by-symbol against `JGE/Dependencies/SDL/include`.

Build config changes are scoped to `unix:` (vendored SDL include path now windows-only, link `-lSDL2`/`-lpng`/`-lboost_thread`, `-std=gnu++14` pinned because the codebase still uses `random_shuffle`/`bind2nd`/`ptr_fun`, `-Werror` disabled for GCC 15's newer warning set, duplicate `TestSuiteAI.cpp` entry removed — it is already in `wagic.pri` and double-linked).

Verified: builds clean from this branch on Arch Linux (GCC 15.2, qmake6, sdl2-compat), game boots and plays. `qmake6 wagic-SDL.pro CONFIG+=debug -o Makefile.sdl && make -f Makefile.sdl` (`-o` avoids clobbering the tracked PSP dispatch Makefile). Related issues: #1080, #1083.