### PR TITLE
Fix deathtouch (and lifelink/wither) ignoring taught-ability damage

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/deathtouch_taught_i1142.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/deathtouch_taught_i1142.txt
+++ b/projects/mtg/bin/Res/test/generic/deathtouch_taught_i1142.txt
@@ -1,0 +1,31 @@
+#Upstream issue #1142: deathtouch must apply to NON-combat damage dealt via
+#a taught activated ability (Power of Fire / Viridian Longbow / Fire Whip).
+#The taught ability's damage source must be the enchanted creature, so its
+#deathtouch destroys the damaged creature even though only 1 damage is dealt.
+#Toxic Iguanar has deathtouch while a green permanent (Grizzly Bears) is around.
+#Wall of Fire is 0/5: it only dies to 1 damage if deathtouch applies.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:Power of Fire
+inplay:Toxic Iguanar,Grizzly Bears
+manapool:{1}{R}
+life:20
+[PLAYER2]
+inplay:Wall of Fire
+life:20
+[DO]
+Power of Fire
+Toxic Iguanar
+Toxic Iguanar
+Wall of Fire
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:Power of Fire,Toxic Iguanar,Grizzly Bears
+manapool:{0}
+life:20
+[PLAYER2]
+graveyard:Wall of Fire
+life:20
+[END]

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -3558,7 +3558,10 @@ public:
         {
             if (d->type_as_damageable == Damageable::DAMAGEABLE_MTGCARDINSTANCE)
             {
-                a->source = (MTGCardInstance *) d;
+                //Repoint the whole ability tree, not just the wrapper: the
+                //nested effect's source is what damage/deathtouch/lifelink
+                //rules inspect (upstream issue #1142).
+                MTGAbility::propagateSource(a, (MTGCardInstance *) d);
             }
             if (oneShot)
             {
@@ -3709,7 +3712,10 @@ public:
         {
             if (d->type_as_damageable == Damageable::DAMAGEABLE_MTGCARDINSTANCE)
             {
-                a->source = (MTGCardInstance *) d;
+                //Repoint the whole ability tree, not just the wrapper: the
+                //nested effect's source is what damage/deathtouch/lifelink
+                //rules inspect (upstream issue #1142).
+                MTGAbility::propagateSource(a, (MTGCardInstance *) d);
             }
             if (oneShot)
             {

--- a/projects/mtg/include/MTGAbility.h
+++ b/projects/mtg/include/MTGAbility.h
@@ -56,6 +56,11 @@ protected:
      // returns target itself if it is a player, or its controller if it is a card
      static Player * getPlayerFromDamageable(Damageable * target);
 public:
+    // Repoints the source of an ability AND its nested/multi children.
+    // Needed when an ability is granted to another card (teach): effects
+    // that depend on the damage/effect source (deathtouch, lifelink...)
+    // must see the taught card, not the teaching aura/equipment.
+    static void propagateSource(MTGAbility * a, MTGCardInstance * newSource);
     enum
     {
         NO_RESTRICTION = 0,

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -7256,6 +7256,25 @@ NestedAbility::NestedAbility(MTGAbility * _ability)
     ability = _ability;
 }
 
+void MTGAbility::propagateSource(MTGAbility * a, MTGCardInstance * newSource)
+{
+    if (!a || !newSource)
+        return;
+    a->source = newSource;
+    //Wrappers (GenericActivatedAbility & co) hold the real effect nested
+    //inside; resolve() forwards target but reads source from the child.
+    if (NestedAbility * na = dynamic_cast<NestedAbility *>(a))
+    {
+        if (na->ability != a) //defensive: avoid pathological self-nesting
+            propagateSource(na->ability, newSource);
+    }
+    if (MultiAbility * ma = dynamic_cast<MultiAbility *>(a))
+    {
+        for (size_t i = 0; i < ma->abilities.size(); ++i)
+            propagateSource(ma->abilities[i], newSource);
+    }
+}
+
 //
 
 ActivatedAbility::ActivatedAbility(GameObserver* observer, int id, MTGCardInstance * card, ManaCost * _cost, int restrictions,string limit,MTGAbility * sideEffect,string usesBeforeSideEffects,string castRestriction) :


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #1142.

Creatures granted a damage ability by an aura or equipment (Power of Fire, Fire Whip, Viridian Longbow — `teach(creature) {T}:damage:1 target(anytarget)`) did not destroy what they damaged, even with deathtouch. Combat deathtouch worked fine.

**Root cause:** `ATeach::_added` and `ALord::_added` repoint only the cloned wrapper ability's `source` to the taught creature. The actual effect (`AADamager` etc.) lives nested inside the wrapper, and `GenericActivatedAbility::resolve()` forwards the *target* but reads *source* from the nested child — which still pointed at the teaching aura/equipment. Damage therefore resolved with the aura as its source, and `MTGDeathtouchRule` (which inspects the damage source's abilities) correctly declined to fire.

**Fix:** new `MTGAbility::propagateSource()` repoints `source` through the whole nested/multi ability tree; both grant sites now use it. This also repairs lifelink, wither/infect, and any other source-dependent rule for taught and lord-granted abilities.

**Regression test:** `test/generic/deathtouch_taught_i1142.txt` — a 0/5 Wall of Fire damaged for 1 by a Power-of-Fire-enchanted Toxic Iguanar can only die if deathtouch flows through the taught ability. Verified with the full test suite in our fork (726 tests, 0 failures; Linux build from #1153).