### PR TITLE
Headless test suite runs via WAGIC_TESTSUITE=1

### DIFF
--- a/projects/mtg/src/GameStateDuel.cpp
+++ b/projects/mtg/src/GameStateDuel.cpp
@@ -911,6 +911,14 @@ void GameStateDuel::Update(float dt)
                     testSuite->initGame(game);
                 }
                 else {
+                    //Headless runs (WAGIC_TESTSUITE=1) exit with a
+                    //CI-friendly status code when the suite completes.
+                    if (getenv("WAGIC_TESTSUITE"))
+                    {
+                        fprintf(stderr, "Test suite finished: %d tests (%d failed), %d AI tests (%d failed)\n",
+                                testSuite->nbTests, testSuite->nbFailed, testSuite->nbAITests, testSuite->nbAIFailed);
+                        exit((testSuite->nbFailed + testSuite->nbAIFailed) ? 1 : 0);
+                    }
                     setGamePhase(DUEL_STATE_END);
                 }
             }

--- a/projects/mtg/src/GameStateMenu.cpp
+++ b/projects/mtg/src/GameStateMenu.cpp
@@ -613,8 +613,26 @@ void GameStateMenu::Update(float dt)
         currentState &= MENU_STATE_MAJOR_MAINMENU;
         options.reloadProfile(); //Handles building a new deck, if needed.
         break;
-    case MENU_STATE_MAJOR_MAINMENU: 
+    case MENU_STATE_MAJOR_MAINMENU:
         {
+#ifdef TESTSUITE
+            //Headless-ish test runs: WAGIC_TESTSUITE=1 jumps straight into
+            //the test suite from the main menu (same effect as selecting it
+            //in the debug submenu). Results land in test/results.html.
+            static bool autoTestSuiteTried = false;
+            if (!autoTestSuiteTried && getenv("WAGIC_TESTSUITE"))
+            {
+                autoTestSuiteTried = true;
+                fprintf(stderr, "WAGIC_TESTSUITE: auto-launching test suite\n");
+                mParent->rules = Rules::getRulesByFilename("testsuite.txt");
+                hasChosenGameType = true;
+                mParent->gameType = GAME_TYPE_CLASSIC;
+                mParent->players[0] = PLAYER_TYPE_TESTSUITE;
+                mParent->players[1] = PLAYER_TYPE_TESTSUITE;
+                currentState = MENU_STATE_MAJOR_DUEL;
+                break;
+            }
+#endif
             if (!scrollerSet)
                 fillScroller();
             ensureMGuiController();


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

The built-in regression suite (TESTSUITE debug builds) is only reachable by clicking through the main-menu submenu, which makes automated runs impossible. With this change, setting `WAGIC_TESTSUITE=1` in the environment makes the game jump straight from the main menu into the test suite, and exit with a CI-friendly status code (0 = all passed, 1 = failures) plus a one-line stderr summary when the suite completes:

```
WAGIC_TESTSUITE=1 ./wagic ; echo $?
# Test suite finished: 726 tests (0 failed), 1 AI tests (0 failed)
```

Behavior is unchanged when the variable is not set (the menu item works as before). One setup note: a language must already be chosen (`User/settings/options.txt` containing `Lang=en`), otherwise the game parks on the first-run language menu before reaching the main menu.

This could eventually back a Linux CI job that runs the full suite on every PR. Related: #1023, #706.