### PR TITLE
Regression test for the Entomb / library-to-graveyard end-of-turn crash

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/entomb_eot_crash_i1120.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/entomb_eot_crash_i1120.txt
+++ b/projects/mtg/bin/Res/test/generic/entomb_eot_crash_i1120.txt
@@ -1,0 +1,30 @@
+#Upstream issue #1120: casting a library-to-graveyard searcher (Entomb /
+#Buried Alive use Reveal: + transforms(newability[moveto(mygraveyard)]))
+#works, but the game crashes at end of turn. This test reproduces the
+#sequence: cast Entomb, choose a card, then run the turn to completion.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:Entomb
+manapool:{B}
+library:Grizzly Bears,Llanowar Elves,Forest,Mountain,Island
+[PLAYER2]
+[DO]
+Entomb
+choice 0
+Grizzly Bears
+next
+next
+next
+next
+next
+next
+next
+next
+[ASSERT]
+UPKEEP
+[PLAYER1]
+graveyard:Entomb,Grizzly Bears
+library:Llanowar Elves,Forest,Mountain,Island
+[PLAYER2]
+[END]


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Issue #1120 reports a crash at end of turn after casting Entomb / Buried Alive (the `Reveal:` + `transforms(newability[moveto(mygraveyard)])` pattern), on Windows and Android release 0.25.5.

The exact reported recipe — cast Entomb, choose a creature through the reveal menus, run the turn to completion — executes cleanly on current master: we ran it under AddressSanitizer on Linux (build from #1153) with no memory errors and a clean turn rollover. The bug appears to have been fixed at some point between the 0.25.5 release and current master, so #1120 can probably be closed once a new release ships.

This adds the scenario as a permanent suite test (`test/generic/entomb_eot_crash_i1120.txt`) so the behavior cannot silently regress.