### PR TITLE
Fix delayed phase actions firing a turn late or not at all

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,8 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/arcane_denial_i1126.txt
+generic/kraul_whipcracker_i1136.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/arcane_denial_i1126.txt
+++ b/projects/mtg/bin/Res/test/generic/arcane_denial_i1126.txt
@@ -1,0 +1,34 @@
+#Upstream issue #1126: after Arcane Denial counters a spell, its
+#controller should be offered up to two draws at the next upkeep, and
+#the Denial's caster should draw one automatically.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:Grizzly Bears
+manapool:{1}{G}
+library:Juggernaut,Ornithopter,Millstone
+life:20
+[PLAYER2]
+hand:Arcane Denial
+manapool:{1}{U}
+library:Rod of Ruin,Howling Mine,Icy Manipulator
+life:20
+[DO]
+Grizzly Bears
+no
+yes
+Arcane Denial
+Grizzly Bears
+endinterruption
+goto upkeep
+[ASSERT]
+UPKEEP
+[PLAYER1]
+hand:Millstone,Ornithopter
+graveyard:Grizzly Bears
+library:Juggernaut
+[PLAYER2]
+hand:Icy Manipulator
+graveyard:Arcane Denial
+library:Rod of Ruin,Howling Mine
+[END]

--- a/projects/mtg/bin/Res/test/generic/kraul_whipcracker_i1136.txt
+++ b/projects/mtg/bin/Res/test/generic/kraul_whipcracker_i1136.txt
@@ -1,0 +1,30 @@
+#Upstream issue #1136: Kraul Whipcracker entering via Momir could not
+#destroy any tokens. P2 momirs Llanowar Elves (a token); P1 then momirs
+#Kraul Whipcracker, which must be able to destroy the Elves token.
+MOMIR
+[INIT]
+SECONDMAIN
+[PLAYER1]
+hand:Mountain
+manapool:{2}
+life:20
+[PLAYER2]
+hand:Plains
+manapool:{1}
+life:20
+[DO]
+goto firstmain
+plains -momir- llanowar elves
+goto end
+goto firstmain
+mountain -momir- kraul whipcracker
+choice 0
+Llanowar Elves
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:*
+graveyard:Mountain
+[PLAYER2]
+graveyard:Plains
+[END]

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -9051,6 +9051,16 @@ MTGAbility(observer, _id, card),sAbility(sAbility), phase(_phase),forcedestroy(f
         psMenuText = sAbility.c_str();
     delete (ability);
 
+    //The 'next' keyword guards against firing during the very phase the
+    //ability was created in: a new ability's first Update synthesizes a
+    //phase 'transition' into the current phase (currentPhase starts as
+    //MTG_PHASE_INVALID), which would fire the action immediately.
+    //When created during any OTHER phase, the first genuine occurrence of
+    //the target phase already IS "the next <phase>" - leaving the guard
+    //armed made every such delayed trigger fire a full turn late
+    //(upstream issue #1126, Arcane Denial's upkeep draws).
+    if (!this->next && game && game->getCurrentGamePhase() != phase)
+        this->next = true;
 }
 
 void APhaseAction::Update(float dt)
@@ -9071,7 +9081,7 @@ void APhaseAction::Update(float dt)
             /*(myturn && opponentturn)*/)
         {
             if(newPhase == phase && next )
-            {
+{
                 MTGCardInstance * _target = NULL;
                 bool isTargetable = false;
                 
@@ -9081,17 +9091,22 @@ void APhaseAction::Update(float dt)
                     isTargetable = (_target && !_target->currentZone && _target != this->source);
                 }
                 
-                if(!sAbility.size() || (!target || isTargetable))
+                //Die without firing when there is nothing to do, or when the
+                //card this action was tracking has vanished from the game.
+                //A NULL target is NOT a reason to skip: self-directed delayed
+                //actions ("you draw a card at the beginning of the next
+                //upkeep" - upstream issue #1126) have no card target and act
+                //from their own source instead.
+                if(!sAbility.size() || (target && isTargetable))
                 {
                     this->forceDestroy = 1;
                     return;
                 }
-                else
-                {
-                    while(_target && _target->next)
-                        _target = _target->next;
-                }
-                
+                while(_target && _target->next)
+                    _target = _target->next;
+                if (!_target)
+                    _target = source;
+
                 AbilityFactory af(game);
                 MTGAbility * ability = af.parseMagicLine(sAbility, abilityId, NULL, _target);
 

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -5899,9 +5899,23 @@ MTGAbility * AbilityFactory::parsePhaseActionAbility(string s,MTGCardInstance * 
     bool once = (s1.find("once") != string::npos);
 
     MTGCardInstance * _target = NULL;
+    bool stackTargetSuppressed = false;
     if (spell)
+    {
         _target = spell->getNextCardTarget();
-    if(!_target)
+        //Counterspells target a spell on the stack, which is gone by the
+        //time a delayed phase action fires; their delayed effects act from
+        //the casting card instead ("You draw a card at the beginning of
+        //the next turn's upkeep" - Arcane Denial, upstream issue #1126).
+        //Card-directed delayed effects on countered spells go through
+        //transforms(newability[...]), which does not pass a spell here.
+        if (_target && _target->currentZone && _target->currentZone == _target->controller()->game->stack)
+        {
+            _target = NULL;
+            stackTargetSuppressed = true;
+        }
+    }
+    if(!_target && !stackTargetSuppressed)
         _target = target;
 
     return NEW APhaseActionGeneric(observer, id, card, _target, trim(splitActions[2]), restrictions, phase, sourceinPlay, next, myturn, opponentturn, once, checkexile);


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #1126 (Arcane Denial: neither the countered player's delayed draws nor the caster's own upkeep draw ever happened). Three coordinated defects in the `phaseaction` machinery, affecting all ~16 cards using the `next` keyword (Besmirch, Treasure Nabber, Medomai, Moraug, Agitator Ant, ...):

1. **One-turn-late firing.** The `next` keyword armed on the first occurrence of the target phase and fired on the second. The arm step exists to guard against the phantom phase 'transition' a newly created ability sees on its first Update (`currentPhase` starts as `MTG_PHASE_INVALID`), which would otherwise fire it immediately when created *during* the target phase. The guard is now applied only in that case; abilities created in any other phase fire at the first genuine occurrence — which is what 'at the beginning of the next <phase>' means.

2. **Silent death of self-directed actions.** `APhaseAction::Update` treated a NULL target as a reason to die without resolving. Self-directed delayed effects ('You draw a card at the beginning of the next turn's upkeep') have no card target; they now fire with their own source as the parse context, which makes `controller` resolve to the right player.

3. **Counterspell target inheritance.** `parsePhaseActionAbility` inherited the casting spell's card target as the delayed action's context. For counterspells that target is a spell on the stack: gone by fire time (so the vanished-target check killed the action), and its controller is the wrong player for self-directed effects. Stack-zone targets are no longer inherited. Card-directed delayed effects on countered spells go through `transforms(newability[...])`, which is unaffected — verified in the regression test (the countered player's draw-2 still works).

**Tests:** `generic/arcane_denial_i1126.txt` drives the full counter interaction (interrupt window, both players' delayed upkeep draws). Also includes `generic/kraul_whipcracker_i1136.txt` pinning issue #1136 (ETB 'destroy target token' entering via Momir), which is **not reproducible on current master** — that issue can likely be closed when a release ships. Full suite: 728 tests, 0 failures (runner from #1155, build from #1153).