### PR TITLE
Proliferate ignores shroud/hexproof/protection (it does not target)

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/proliferate_shroud_i1130.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/proliferate_shroud_i1130.txt
+++ b/projects/mtg/bin/Res/test/generic/proliferate_shroud_i1130.txt
@@ -1,0 +1,47 @@
+#Upstream issue #1130: proliferate could not add counters to shrouded
+#permanents. Proliferate does not target (CR 701.27a), so shroud is
+#irrelevant. Blastoderm (shroud, fading 3) proliferated to 4 fade
+#counters survives through the upkeep where a 3-counter one is already
+#sacrificed. NOTE: goto no-ops when already in the target phase, hence
+#the end/upkeep pairs - each pair advances exactly one upkeep.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:Blastoderm,Steady Progress
+manapool:{2}{G}{G}{2}{U}
+library:Forest,Forest,Forest,Forest,Forest,Forest
+life:20
+[PLAYER2]
+life:20
+[DO]
+Blastoderm
+Steady Progress
+Blastoderm
+next
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+goto end
+goto upkeep
+[ASSERT]
+UPKEEP
+[PLAYER1]
+inplay:Blastoderm
+graveyard:Steady Progress
+hand:*
+library:*,*,*,*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/src/TargetChooser.cpp
+++ b/projects/mtg/src/TargetChooser.cpp
@@ -2441,18 +2441,17 @@ bool dredgeChooser::equals(TargetChooser * tc)
 /*Proliferate Target */
 bool ProliferateChooser::canTarget(Targetable * target, bool withoutProtections)
 {
+    //Proliferate does not target (CR 701.27a): you CHOOSE permanents and
+    //players, so shroud, hexproof and protection are all irrelevant. The
+    //only requirement is that the chosen permanent/player already has at
+    //least one counter. (Upstream issue #1130: shrouded creatures with
+    //counters, e.g. Blastoderm, were excluded.)
     if (Player * p = dynamic_cast<Player*>(target))
     {
-        if (source && (source->controller() != source->controller()->opponent()) && (source->controller()->opponent()->game->inPlay->hasAbility(Constants::CONTROLLERSHROUD)) && source->controller() != target)
-            return source->bypassTC;
-        if (source && (source->controller()->opponent()->game->inPlay->hasAbility(Constants::PLAYERSHROUD)) && source->controller()->opponent() == target)
-            return source->bypassTC;
-        if (source && (source->controller()->game->inPlay->hasAbility(Constants::PLAYERSHROUD)) && source->controller() == target)
-            return source->bypassTC;
         if(source && source->controller()->isAI() && p == source->controller() && p->poisonCount)
-            return false; // prevent AI to target itself when it has some poison counters.
+            return false; // AI guidance: don't worsen our own poison.
         if(source && source->controller()->isAI() && p != source->controller() && !p->poisonCount)
-            return false; // prevent AI to target opponent when there are no poison counters.
+            return false; // AI guidance: nothing useful to add on the opponent.
         if(!p->poisonCount && !p->energyCount && !p->experienceCount)
             return false;
         return true;
@@ -2461,17 +2460,6 @@ bool ProliferateChooser::canTarget(Targetable * target, bool withoutProtections)
     {
         if(!observer || !card->isInPlay(observer))
             return false;
-        if (source && !withoutProtections)
-        { 
-            if (card->has(Constants::SHROUD)) return source->bypassTC;
-            if (card->protectedAgainst(source)) return source->bypassTC;
-            if (card->CantBeTargetby(source)) return source->bypassTC;
-            if ((source->controller() != card->controller()) && card->has(Constants::HEXPROOF)) return source->bypassTC;
-            if (card->has(Constants::PROTECTIONFROMCOLOREDSPELLS)){
-                if((source->spellTargetType.size()) && (source->hasColor(1)||source->hasColor(2)||source->hasColor(3)||source->hasColor(4)||source->hasColor(5)))
-                    return source->bypassTC;
-            }
-        }
         if(!card->counters || (card->counters && card->counters->counters.empty()))
             return false;
         return true;

--- a/projects/mtg/src/TestSuiteAI.cpp
+++ b/projects/mtg/src/TestSuiteAI.cpp
@@ -269,6 +269,7 @@ void TestSuiteActions::add(string s)
 
 TestSuiteState::TestSuiteState()
 {
+    phase = MTG_PHASE_INVALID;
     players.clear();
 }
 
@@ -352,8 +353,14 @@ void TestSuiteGame::assertGame()
 
     if (observer->getCurrentGamePhase() != endState.phase)
     {
-        sprintf(result, "<span class=\"error\">==phase problem. Expected [ %s ](%i), got [ %s ](%i)==</span><br />", 
-            Constants::MTGPhaseNames[endState.phase].c_str(),endState.phase,
+        //A garbage/uninitialized expected phase means the test file's
+        //[ASSERT] section was missing or never parsed - report it instead
+        //of indexing MTGPhaseNames out of bounds (used to crash).
+        const char * expectedName = (endState.phase >= 0 && endState.phase < NB_MTG_PHASES)
+            ? Constants::MTGPhaseNames[endState.phase].c_str()
+            : "INVALID - missing/unparsed [ASSERT] section?";
+        sprintf(result, "<span class=\"error\">==phase problem. Expected [ %s ](%i), got [ %s ](%i)==</span><br />",
+            expectedName, endState.phase,
             Constants::MTGPhaseNames[observer->getCurrentGamePhase()].c_str(), observer->getCurrentGamePhase());
         Log(result);
         error++;


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #1130 (a shrouded Blastoderm with fade counters could not be chosen when proliferating).

Proliferate does not target (CR 701.27a): the player **chooses** any number of permanents and players with counters, so shroud, hexproof and protection-from are all irrelevant to it. `ProliferateChooser::canTarget` was running the full targeting-protection suite; it now only requires the chosen permanent/player to already have a counter on it. The AI guidance heuristics (don't worsen your own poison, don't add counters for the opponent's benefit) are kept.

The regression test proves the fix with Blastoderm's own fading clock: chosen by Steady Progress's proliferate it carries 4 fade counters and is still alive at the upkeep where an unproliferated 3-counter Blastoderm is already sacrificed — verified in both directions (the counterfactual without the proliferate has it in the graveyard at that same upkeep).

Also hardens the test harness: a missing/unparsed `[ASSERT]` section used to **crash** `assertGame` by indexing `MTGPhaseNames` with a garbage expected phase; it now reports the malformed test as a failure instead (`TestSuiteState.phase` initialized to `MTG_PHASE_INVALID`).

Full suite: 732 tests, 0 failures (runner from #1155, build from #1153).