### PR TITLE
Copies don't inherit exile-at-end-step riders; tokens clickable in the test suite

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/populate_zektar_i1145.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/populate_zektar_i1145.txt
+++ b/projects/mtg/bin/Res/test/generic/populate_zektar_i1145.txt
@@ -1,0 +1,28 @@
+#Upstream issue #1145: populating a token that carries an
+#'exile at the beginning of the next end step' rider (Zektar Shrine
+#Expedition, Elemental Appeal...) exiled the COPY as well. The rider is
+#a delayed effect on the original, not a copiable characteristic.
+#Feral Lightning makes three rider tokens; Druid's Deliverance populates one.
+#After the end step: original Elemental exiled, populated copy remains.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:Feral Lightning,Druid's Deliverance
+manapool:{3}{R}{R}{R}{1}{G}
+life:20
+[PLAYER2]
+life:20
+[DO]
+Feral Lightning
+Druid's Deliverance
+choice 0
+Elemental
+goto end
+goto upkeep
+[ASSERT]
+UPKEEP
+[PLAYER1]
+inplay:*
+graveyard:Feral Lightning,Druid's Deliverance
+[PLAYER2]
+[END]

--- a/projects/mtg/include/MTGCardInstance.h
+++ b/projects/mtg/include/MTGCardInstance.h
@@ -79,6 +79,11 @@ public:
     int flanked;
     int regenerateTokens;
     int isToken;
+    //Copies (populate, Clone...) must not inherit 'exile at the next end
+    //step' riders from the original; this flag survives instance copies
+    //and masks those bits when basicAbilities are rebuilt from data
+    //(upstream issue #1145).
+    bool exileRiderSuppressed;
     int origpower;
     int basepower;//to keep origpower intact
     int pbonus;

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -6155,6 +6155,17 @@ int AACloner::resolve()
         spell->source->model->data = spell->source;
         spell->source->tokCard = spell->source->clone();
         spell->source->TokenAndAbility = _target->TokenAndAbility;//token andAbility
+        //'Exile it at the beginning of the next end step' / unearth-style
+        //riders are delayed effects attached by whatever created the
+        //ORIGINAL - they are not copiable characteristics, so a copy
+        //(populate, Clone...) must not inherit them (upstream issue #1145,
+        //Zektar Shrine Expedition's populated Elemental). The flag survives
+        //instance copies and masks the bits whenever basicAbilities are
+        //rebuilt from the (shared) token model.
+        spell->source->exileRiderSuppressed = true;
+        spell->source->basicAbilities[Constants::UNEARTH] = 0;
+        spell->source->basicAbilities[Constants::EXILEDEATH] = 0;
+        spell->source->basicAbilities[Constants::GAINEDEXILEDEATH] = 0;
         //if the token doesn't have cda/dynamic pt then allow this...
         if((_target->isToken) && (!_target->isCDA))
         {

--- a/projects/mtg/src/MTGCardInstance.cpp
+++ b/projects/mtg/src/MTGCardInstance.cpp
@@ -134,6 +134,13 @@ void MTGCardInstance::copy(MTGCardInstance * card, bool nolegend)
         if(data->basicAbilities[j])
             basicAbilities[j] = data->basicAbilities[j];
     }
+    exileRiderSuppressed = card->exileRiderSuppressed;
+    if (exileRiderSuppressed)
+    {
+        basicAbilities[Constants::UNEARTH] = 0;
+        basicAbilities[Constants::EXILEDEATH] = 0;
+        basicAbilities[Constants::GAINEDEXILEDEATH] = 0;
+    }
     types.clear();//reset types.. fix copying man lands... the copier becomes an unanimated land...
     for (size_t i = 0; i < data->types.size(); i++)
     {
@@ -217,6 +224,7 @@ void MTGCardInstance::initMTGCI()
     sample = "";
     model = NULL;
     isToken = false;
+    exileRiderSuppressed = false;
     lifeOrig = 0;
     doDamageTest = 1;
     skipDamageTestOnce = false;
@@ -2094,5 +2102,15 @@ std::ostream& operator<<(std::ostream& out, const MTGCardInstance& c)
 
 MTGCardInstance* MTGCardInstance::clone()
 {
-    return NEW MTGCardInstance(model, owner->game);
+    MTGCardInstance * c = NEW MTGCardInstance(model, owner->game);
+    //zone moves rebuild instances from the model; the rider-suppression
+    //flag of copies (populate, Clone...) must survive (issue #1145)
+    c->exileRiderSuppressed = exileRiderSuppressed;
+    if (c->exileRiderSuppressed)
+    {
+        c->basicAbilities[Constants::UNEARTH] = 0;
+        c->basicAbilities[Constants::EXILEDEATH] = 0;
+        c->basicAbilities[Constants::GAINEDEXILEDEATH] = 0;
+    }
+    return c;
 }

--- a/projects/mtg/src/TestSuiteAI.cpp
+++ b/projects/mtg/src/TestSuiteAI.cpp
@@ -42,7 +42,15 @@ TestSuiteAI::TestSuiteAI(TestSuiteGame *tsGame, int playerId) :
 MTGCardInstance * TestSuiteAI::getCard(string action)
 {
     int mtgid = Rules::getMTGId(action);
-    if (mtgid) return Rules::getCardByMTGId(observer, mtgid);
+    if (mtgid)
+    {
+        MTGCardInstance * byId = Rules::getCardByMTGId(observer, mtgid);
+        if (byId)
+            return byId;
+        //Fall through to the name scan: a token NAME can resolve to the
+        //token model registered in the collection, whose id no live
+        //instance carries (each token instance has its own generated id).
+    }
 
     //This mostly handles tokens
     std::transform(action.begin(), action.end(), action.begin(), ::tolower);


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #1145 (populating a Zektar Shrine Expedition token exiled the populated copy at the end step too).

'Exile it at the beginning of the next end step' is a delayed effect attached by whatever created the **original** token — not a copiable characteristic — so a populated/cloned copy must not inherit it. In the engine the rider is baked into the token model as the `UNEARTH` basic ability (13 token makers use it: Zektar Shrine Expedition, Feral Lightning, Elemental Appeal, ...), which copies picked up wholesale.

`AACloner` now strips `UNEARTH`/`EXILEDEATH`/`GAINEDEXILEDEATH` from the copy and marks it with a new `exileRiderSuppressed` flag that survives instance rebuilds — zone moves recreate instances **from the model** (`MTGCardInstance::clone()`) and `MTGCardInstance::copy()` re-derives `basicAbilities` from `data`, so instance-level bit edits alone are transient. The flag is propagated and re-masks the bits at both rebuild sites. The shared token model itself is deliberately never mutated (it is aliased with the original token's data).

Also fixes a test-harness bug this surfaced: **clicking a token by name was impossible** — `TestSuiteAI::getCard` resolved the name to the token model registered in the collection (an id no live instance carries) and returned NULL without falling through to the zone-by-name scan. It now falls through, unblocking token interactions for future tests.

Regression test: Feral Lightning makes three rider tokens, Druid's Deliverance populates one; at the next upkeep the three originals are exiled and the copy remains. The counterfactual without the strip exiles all four. Full suite: 733 tests, 0 failures (runner from #1155, build from #1153).