### PR TITLE
Revive death_grasp.txt: the test was stale, not the engine

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+death_grasp.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/death_grasp.txt
+++ b/projects/mtg/bin/Res/test/death_grasp.txt
@@ -11,8 +11,8 @@ manapool:{W}{B}{10}
 [DO]
 Death Grasp
 choice 10
+choice 0
 p2
-Death Grasp
 [ASSERT]
 firstmain
 [PLAYER1]


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Addresses half of #1023 (test suite broken: `death_grasp.txt` and `ai/goblin_artillery.txt`).

`death_grasp.txt` predates the current interaction model and could never pass: it chose the X value and clicked the target player but never answered the damage ability's prompt at spell resolution, and carried a stray trailing click. With the interaction sequence updated — cast, `choice 10` (X menu at cast), `choice 0` (accept the damage ability at resolution), `p2` (player target) — Death Grasp deals 10 and gains 10 exactly as printed, and the test passes. Re-enlisted in `_tests.txt`; the full suite stands at 734 tests, 0 failures with it (runner from #1155, build from #1153).

`ai/goblin_artillery.txt` is a different animal: it fails because the **AI never activates Goblin Artillery's ping** — an AI-heuristics gap (the #1079 family), not an engine or test-script problem. It stays delisted; fixing it means teaching AIPlayerBaka to value activated damage abilities, which deserves its own change.