### PR TITLE
AI: stop dropping equally-rated actions; prefer kills over chip damage

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+ai/goblin_artillery.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/include/AIPlayerBaka.h
+++ b/projects/mtg/include/AIPlayerBaka.h
@@ -59,8 +59,17 @@ public:
         OrderedAIAction* a2Ptr = const_cast<OrderedAIAction*>(&a2);
         int e1 = a1Ptr->getEfficiency();
         int e2 = a2Ptr->getEfficiency();
-        if (e1 == e2) return a1Ptr->id < a2Ptr->id;
-        return (e1 > e2);
+        if (e1 != e2) return (e1 > e2);
+        if (a1Ptr->id != a2Ptr->id) return a1Ptr->id < a2Ptr->id;
+        //Same ability, same efficiency: tie-break on the actual action
+        //identity. Without this, equally-rated targets of one ability
+        //collapse into a single map key and all but one are silently
+        //dropped from the ranking - a major cause of 'the AI never
+        //plays/aims this card right' reports (upstream issue #1079).
+        if (a1Ptr->target != a2Ptr->target) return a1Ptr->target < a2Ptr->target;
+        if (a1Ptr->playerAbilityTarget != a2Ptr->playerAbilityTarget) return a1Ptr->playerAbilityTarget < a2Ptr->playerAbilityTarget;
+        if (a1Ptr->player != a2Ptr->player) return a1Ptr->player < a2Ptr->player;
+        return a1Ptr->click < a2Ptr->click;
     }
 };
 

--- a/projects/mtg/src/AIPlayerBaka.cpp
+++ b/projects/mtg/src/AIPlayerBaka.cpp
@@ -53,7 +53,10 @@ int OrderedAIAction::getEfficiency(AADamager * aad)
     if (dTarget && aad && (aad->getDamage() == dTarget->toughness))
         return 100;
     else if (dTarget && aad && (aad->getDamage() > dTarget->toughness))
-        return 10 * (10 - (aad->getDamage() - dTarget->toughness)); //less eff the more dmg above toughness
+        //A kill with slight overkill must still outrank chip damage to the
+        //player's face (90 - otherTargets above); waste-heavy overkill
+        //decays below it (upstream issue #1079 / ai/goblin_artillery.txt).
+        return 95 - 10 * (aad->getDamage() - dTarget->toughness - 1);
     else
         return 10;
 


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes the root cause behind `ai/goblin_artillery.txt` (the second half of #1023) and a major class of #1079 'the AI never plays / misaims this card' reports.

Two defects in the ability-ranking pipeline:

1. **Equally-rated actions were silently dropped.** `RankingContainer` is a `std::map` keyed by `OrderedAIAction` under `CmpAbilities`, which compared only (efficiency, ability id). Two different targets of the same ability with equal efficiency formed **equal map keys**, so all but one were discarded — the AI literally could not see those options. In the goblin_artillery scenario, the 'kill Raging Goblin' action never entered the ranking at all (verified by logging the ranking: only the two player targets were present). The comparator now tie-breaks on full action identity (card target, player-ability target, player, clicked card).

2. **Kills tied with chip damage, and the tie went to the face.** The AADamager overkill score `10 * (10 - overkill)` rated a one-point-overkill creature kill (90) identically to hitting the opponent's face (`90 - otherTargets`). Near-exact kills now outrank chip damage (`95 - 10 * (overkill - 1)`), while waste-heavy overkill still decays below it.

`ai/goblin_artillery.txt` — failing since the Google Code days (issue 194, 'ai uses goblin artillery on own creature') — now passes: the AI activates the artillery, kills Raging Goblin, and takes its 3 self-damage. Re-enlisted in `_tests.txt`. Full suite: 734 tests + 2 AI tests, 0 failures (runner from #1155, build from #1153).