### PR TITLE
Serum Powder: keep the opening-hand window open; only offer the redraw inside it

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,8 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/serum_powder_leyline_i979.txt
+generic/serum_powder_window_i979.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/serum_powder_leyline_i979.txt
+++ b/projects/mtg/bin/Res/test/generic/serum_powder_leyline_i979.txt
@@ -1,0 +1,22 @@
+#Bug: Serum Powder's redraw exiles the hand, which wrongly closed the
+#opening-hand window: Leylines drawn after the redraw could no longer
+#begin the game on the battlefield.
+# https://github.com/WagicProject/wagic/issues/979
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:serum powder,juggernaut
+library:leyline of sanctity,millstone
+[PLAYER2]
+[DO]
+serum powder
+choice 0
+leyline of sanctity
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:leyline of sanctity
+hand:millstone
+exile:serum powder,juggernaut
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/serum_powder_window_i979.txt
+++ b/projects/mtg/bin/Res/test/generic/serum_powder_window_i979.txt
@@ -1,0 +1,20 @@
+#Bug: Serum Powder's redraw is only legal "any time you could mulligan",
+#but it stayed clickable for the whole game.
+# https://github.com/WagicProject/wagic/issues/979
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:serum powder,juggernaut
+library:leyline of sanctity,millstone
+[PLAYER2]
+[DO]
+goto secondmain
+serum powder
+choice 0
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+hand:serum powder,juggernaut
+library:leyline of sanctity,millstone
+[PLAYER2]
+[END]

--- a/projects/mtg/include/AllAbilities.h
+++ b/projects/mtg/include/AllAbilities.h
@@ -6933,6 +6933,8 @@ class AAMulligan: public ActivatedAbilityTP
 public:
     AAMulligan(GameObserver* observer, int _id, MTGCardInstance * card, Targetable * _target, ManaCost * _cost = NULL, int who =
             TargetChooser::UNSET);
+    bool mulliganWindowOpen();
+    int isReactingToClick(MTGCardInstance * card, ManaCost * mana = NULL);
     int resolve();
     const string getMenuText();
     AAMulligan * clone() const;

--- a/projects/mtg/include/Player.h
+++ b/projects/mtg/include/Player.h
@@ -53,6 +53,12 @@ public:
     int surveilOffset;
     int devotionOffset;
     int lastShuffleTurn;
+    //Number of cards this player exiled via Serum Powder's redraw. The
+    //opening-hand rules (Leylines, the Mulligan menu) detect the pre-game
+    //window by "graveyard and exile are empty"; Serum Powder legitimately
+    //fills exile before the game starts, so those checks compare against
+    //this count instead of zero.
+    int exiledBySerum;
     int epic;
     int forcefield;
     int dealsdamagebycombat;

--- a/projects/mtg/src/AllAbilities.cpp
+++ b/projects/mtg/src/AllAbilities.cpp
@@ -993,6 +993,10 @@ int GenericActivatedAbility::isReactingToClick(MTGCardInstance * card, ManaCost 
 {
     if (dynamic_cast<AAMorph*> (ability) && !card->isMorphed && !card->morphed && card->turningOver)
         return 0;
+    //Serum Powder's redraw is only available "any time you could mulligan"
+    if (AAMulligan * mulligan = dynamic_cast<AAMulligan*> (ability))
+        if (!mulligan->mulliganWindowOpen())
+            return 0;
     return ActivatedAbility::isReactingToClick(card, mana);
 }
 
@@ -6799,6 +6803,32 @@ AAShuffle::~AAShuffle()
 AAMulligan::AAMulligan(GameObserver* observer, int _id, MTGCardInstance * card, Targetable * _target, ManaCost * _cost, int who) :
     ActivatedAbilityTP(observer, _id, card, _target, _cost, who)
 {
+}
+
+bool AAMulligan::mulliganWindowOpen()
+{
+    //"Any time you could mulligan" (Serum Powder): only while the
+    //opening-hand window is open, same as the Mulligan menu entry -
+    //the first player's first main phase, or the second player's first
+    //turn before drawing, with no game actions taken yet. Cards exiled
+    //by previous Serum Powder redraws don't end the window (issue #979).
+    Player * p = source->controller();
+    GamePhase phase = (GamePhase)game->getCurrentGamePhase();
+    if (!((game->turn == 0 && phase == MTG_PHASE_FIRSTMAIN) || (game->turn == 1 && phase < MTG_PHASE_DRAW)))
+        return false;
+    if (p != game->currentPlayer || game->currentlyActing() != p)
+        return false;
+    if (p->game->inPlay->nb_cards != 0 || p->game->graveyard->nb_cards != 0
+        || p->game->exile->nb_cards != p->exiledBySerum)
+        return false;
+    return true;
+}
+
+int AAMulligan::isReactingToClick(MTGCardInstance * card, ManaCost * mana)
+{
+    if (!mulliganWindowOpen())
+        return 0;
+    return ActivatedAbilityTP::isReactingToClick(card, mana);
 }
 
 int AAMulligan::resolve()

--- a/projects/mtg/src/GameStateDuel.cpp
+++ b/projects/mtg/src/GameStateDuel.cpp
@@ -960,7 +960,7 @@ void GameStateDuel::Update(float dt)
                     //almosthumane - mulligan
                     if (((game->turn == 0 && game->getCurrentGamePhase() == MTG_PHASE_FIRSTMAIN) || (game->turn == 1 && game->getCurrentGamePhase() < MTG_PHASE_DRAW))
                         && game->currentPlayer->game->hand->nb_cards > 0 && game->currentPlayer->game->inPlay->nb_cards == 0 && game->currentPlayer->game->graveyard->nb_cards == 0
-                        && game->currentPlayer->game->exile->nb_cards == 0 && game->currentlyActing() == (Player*)game->currentPlayer) //Now you can mulligan even if you didn't start as first.
+                        && game->currentPlayer->game->exile->nb_cards == game->currentPlayer->exiledBySerum && game->currentlyActing() == (Player*)game->currentPlayer) //Now you can mulligan even if you didn't start as first. Serum Powder exiles don't end the window (issue #979).
                     {
                         menu->Add(MENUITEM_MULLIGAN, "Mulligan");
                     }

--- a/projects/mtg/src/MTGRules.cpp
+++ b/projects/mtg/src/MTGRules.cpp
@@ -301,17 +301,20 @@ PermanentAbility(observer, _id)
 
 int MTGPutInPlayRule::isReactingToClick(MTGCardInstance * card, ManaCost *)
 {
-    int cardsinhand = game->players[0]->game->hand->nb_cards;
     defaultPlayName = card->isLand()?"Play Land":"Cast Card Normally";
     Player * player = game->currentlyActing();
     if (!player->game->hand->hasCard(card) && !player->game->graveyard->hasCard(card) && !player->game->exile->hasCard(card) && !player->game->library->hasCard(card) && !player->game->commandzone->hasCard(card))
          return 0;
     if ((player->game->library->hasCard(card) && !card->canPlayFromLibrary()) || (player->game->graveyard->hasCard(card) && !card->has(Constants::CANPLAYFROMGRAVEYARD)) || (player->game->exile->hasCard(card) && !card->has(Constants::CANPLAYFROMEXILE)))
          return 0;
-    if ((game->turn < 1) && (cardsinhand != 0) && (card->basicAbilities[(int)Constants::LEYLINE])
+    //Leylines may start on the battlefield while the opening-hand window is
+    //open. "Nothing has happened yet" is detected through empty zones, but
+    //cards exiled by Serum Powder redraws (player->exiledBySerum) are part
+    //of that window and must not close it (issue #979).
+    if ((game->turn < 1) && (player->game->hand->nb_cards != 0) && (card->basicAbilities[(int)Constants::LEYLINE])
         && game->getCurrentGamePhase() == MTG_PHASE_FIRSTMAIN
-        && game->players[0]->game->graveyard->nb_cards == 0
-        && game->players[0]->game->exile->nb_cards == 0
+        && player->game->graveyard->nb_cards == 0
+        && player->game->exile->nb_cards == player->exiledBySerum
         )
     {
 

--- a/projects/mtg/src/Player.cpp
+++ b/projects/mtg/src/Player.cpp
@@ -43,6 +43,7 @@ Player::Player(GameObserver *observer, string file, string fileSmall, MTGDeck * 
     monarch = 0;
     initiative = 0;
     surveilOffset = 0;
+    exiledBySerum = 0;
     devotionOffset = 0;
     lastShuffleTurn = -1;
     epic = 0;
@@ -261,6 +262,7 @@ void Player::serumMulligan()
 {
     MTGPlayerCards * currentPlayerZones = game;
     int cardsinhand = currentPlayerZones->hand->nb_cards;
+    exiledBySerum += cardsinhand;
     for (int i = 0; i < cardsinhand; i++) //Exile
         currentPlayerZones->putInZone(currentPlayerZones->hand->cards[0],
         currentPlayerZones->hand,
@@ -392,6 +394,11 @@ bool Player::parseLine(const string& s)
             premade = (atoi(s.substr(limiter + 1).c_str())==1);
             return true;
         }
+        else if (areaS.compare("serumexiled") == 0)
+        {
+            exiledBySerum = atoi(s.substr(limiter + 1).c_str());
+            return true;
+        }
         else if (areaS.compare("deckfile") == 0)
         {
             deckFile = s.substr(limiter + 1);
@@ -471,6 +478,8 @@ ostream& operator<<(ostream& out, const Player& p)
         out << "customphasering=" << p.phaseRing << endl;
     out << "offerinterruptonphase=" << Constants::MTGPhaseCodeNames[p.offerInterruptOnPhase] << endl;
     out << "premade=" << p.premade << endl;
+    if(p.exiledBySerum)
+        out << "serumexiled=" << p.exiledBySerum << endl;
     if(p.deckFile != "")
         out << "deckfile=" << p.deckFile << endl;
     if(p.deckFileSmall != "")


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #979.

## What was broken

The engine detects "the game hasn't started yet" — for Leylines beginning on the battlefield (`MTGPutInPlayRule`) and for the Mulligan menu entry (`GameStateDuel`) — by checking that graveyard **and exile** are empty. Serum Powder's redraw exiles your hand, so using it wrongly slammed that window shut: Leylines drawn after the redraw could no longer start on the battlefield, and further mulligans disappeared — breaking exactly the Leyline/Serum Powder decks the card exists for. Meanwhile the redraw itself had no window at all: `autohand={0}:serumpowder` stayed clickable for the entire game, despite "any time you could mulligan".

## The fix

- `Player::exiledBySerum` counts cards exiled by Serum Powder redraws (serialized as `serumexiled=` so save/undo round-trips it). The Leyline gate and the Mulligan menu now compare exile against this count instead of zero, so serum exiles no longer end the opening-hand window.
- The Leyline gate also becomes player-relative (it hardcoded `players[0]`'s zones whoever was acting).
- `AAMulligan::mulliganWindowOpen()` implements "any time you could mulligan" with the same window as the Mulligan menu: the first player's first main phase, or the second player's first turn before drawing, with no game actions taken. Since the card line wraps `AAMulligan` in a `GenericActivatedAbility`, the wrapper consults the inner ability on click — following the existing `AAMorph` special-case precedent there.

## Tests

- `generic/serum_powder_leyline_i979.txt` — redraw into a Leyline of Sanctity, then deploy it to the battlefield from the new hand.
- `generic/serum_powder_window_i979.txt` — the redraw must refuse to fire once the window has closed (second main of turn 0).

Both were verified load-bearing by counterfactual runs (re-breaking either half of the fix makes the corresponding test fail in the originally-reported way).

Full suite on the fork: 736 tests + 3 AI tests, 0 failures.