### PR TITLE
Regression test for #689: a land drop must not block casting a 0-cost spell

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/maxcast_land_then_zerodrop_i689.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/maxcast_land_then_zerodrop_i689.txt
+++ b/projects/mtg/bin/Res/test/generic/maxcast_land_then_zerodrop_i689.txt
@@ -1,0 +1,16 @@
+#Bug: after playing a land, casting a 0-cost spell was refused
+# https://github.com/WagicProject/wagic/issues/689
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:darksteel citadel,memnite
+[PLAYER2]
+[DO]
+darksteel citadel
+memnite
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:darksteel citadel,memnite
+[PLAYER2]
+[END]


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

#689 reported that after playing a land, casting a 0-drop creature was refused (suspected maxCast accounting counting the land drop as a cast).

The scenario works on current master: the new test plays Darksteel Citadel and then casts Memnite in the same first main phase, asserting both end up on the battlefield. Since it isn't reproducible anymore, this just pins the behavior with a regression test — same approach as #1157.

If it passes for you too, #689 can probably be closed.