### PR TITLE
Dreadhorde Arcanist: evaluate "manacost<=power" at match time, not parse time

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/dreadhorde_arcanist_i1125.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/dreadhorde_arcanist_i1125.txt
+++ b/projects/mtg/bin/Res/test/generic/dreadhorde_arcanist_i1125.txt
@@ -1,0 +1,37 @@
+#Bug: Dreadhorde Arcanist's "mana value <= power" check froze power at
+#parse time, so pumping the Arcanist never widened the castable range:
+#a 3/5 Arcanist (two +1/+1 counters) could not cast a mana value 3
+#sorcery from the graveyard.
+# https://github.com/WagicProject/wagic/issues/1125
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:dreadhorde arcanist
+hand:battlegrowth,battlegrowth
+graveyard:divination
+library:millstone,juggernaut
+manapool:{G}{G}
+[PLAYER2]
+[DO]
+battlegrowth
+dreadhorde arcanist
+battlegrowth
+dreadhorde arcanist
+goto attackers
+dreadhorde arcanist
+next
+choice 0
+divination
+goto blockers
+goto blockers
+goto blockers
+goto blockers
+[ASSERT]
+COMBATBLOCKERS
+[PLAYER1]
+inplay:dreadhorde arcanist
+hand:*,*
+exile:divination
+graveyard:battlegrowth,battlegrowth
+[PLAYER2]
+[END]

--- a/projects/mtg/include/CardDescriptor.h
+++ b/projects/mtg/include/CardDescriptor.h
@@ -43,6 +43,13 @@ class CardDescriptor: public MTGCardInstance
   int manacostComparisonMode;
   int counterComparisonMode;
   int convertedManacost; // might fit better into MTGCardInstance?
+  //When the manacost criterion is an expression referencing the source
+  //card's stats ("manacost<=power", Dreadhorde Arcanist), freezing its
+  //value at parse time ignores later pumps (issue #1125). The expression
+  //is kept and re-evaluated against the source at match time.
+  string dynamicManacostExpression;
+  MTGCardInstance * dynamicManacostSource;
+  int currentManacostCriterion();
   int zposComparisonMode;
   int zposition;
   int numofColorsComparisonMode;

--- a/projects/mtg/src/CardDescriptor.cpp
+++ b/projects/mtg/src/CardDescriptor.cpp
@@ -22,6 +22,8 @@ CardDescriptor::CardDescriptor()
     manacostComparisonMode = COMPARISON_NONE;
     counterComparisonMode = COMPARISON_NONE;
     convertedManacost = -1;
+    dynamicManacostExpression = "";
+    dynamicManacostSource = NULL;
     numofColorsComparisonMode = COMPARISON_NONE;
     numofColors = -1;
     zposComparisonMode = COMPARISON_NONE;
@@ -140,6 +142,19 @@ void CardDescriptor::setNegativeSubtype(string value)
 
 // Very generic function to compare a value to a criterion.
 // Should be easily transferable to a more generic class if desired.
+//The manacost criterion may be an expression over the source card's
+//current stats ("manacost<=power"); evaluate it fresh so pumps and
+//counters are respected at match time (issue #1125).
+int CardDescriptor::currentManacostCriterion()
+{
+    if (dynamicManacostExpression.size() && dynamicManacostSource)
+    {
+        WParsedInt val(dynamicManacostExpression, NULL, dynamicManacostSource);
+        return val.getValue();
+    }
+    return convertedManacost;
+}
+
 bool CardDescriptor::valueInRange(int comparisonMode, int value, int criterion)
 {
     switch (comparisonMode)
@@ -230,7 +245,7 @@ MTGCardInstance * CardDescriptor::match_or(MTGCardInstance * card)
         if(!valueInRange(numofColorsComparisonMode, totalcolor, numofColors))
             return NULL;
     }
-    if (manacostComparisonMode && !valueInRange(manacostComparisonMode, card->myconvertedcost, convertedManacost))
+    if (manacostComparisonMode && !valueInRange(manacostComparisonMode, card->myconvertedcost, currentManacostCriterion()))
         return NULL;
     if (zposComparisonMode && !valueInRange(zposComparisonMode, card->zpos, zposition))
         return NULL;
@@ -297,7 +312,7 @@ MTGCardInstance * CardDescriptor::match_and(MTGCardInstance * card)
         if(!valueInRange(numofColorsComparisonMode, totalcolor, numofColors))
             return NULL;
     }
-    if (manacostComparisonMode && !valueInRange(manacostComparisonMode, card->myconvertedcost, convertedManacost))
+    if (manacostComparisonMode && !valueInRange(manacostComparisonMode, card->myconvertedcost, currentManacostCriterion()))
         match = NULL;
     if (zposComparisonMode && !valueInRange(zposComparisonMode, card->zpos, zposition))
         match = NULL;

--- a/projects/mtg/src/TargetChooser.cpp
+++ b/projects/mtg/src/TargetChooser.cpp
@@ -588,12 +588,14 @@ TargetChooser * TargetChooserFactory::createTargetChooser(string s, MTGCardInsta
                 }
                 int comparisonMode = COMPARISON_NONE;
                 int comparisonCriterion = 0;
+                string comparisonExpression = "";
                 if (attribute.size() > 1)
                 {
                     size_t operatorPosition = attribute.find("=", 1);
                     if (operatorPosition != string::npos)
                     {
                         string numberCD = attribute.substr(operatorPosition + 1, attribute.size() - operatorPosition - 1);
+                        comparisonExpression = numberCD;
                         WParsedInt * val = NEW WParsedInt(numberCD,NULL, card);
                         comparisonCriterion = val->getValue();
                         delete val;           
@@ -1098,6 +1100,16 @@ TargetChooser * TargetChooserFactory::createTargetChooser(string s, MTGCardInsta
                     //Manacost restrictions
                     cd->convertedManacost = comparisonCriterion;
                     cd->manacostComparisonMode = comparisonMode;
+                    //"manacost<=power" (Dreadhorde Arcanist): the criterion
+                    //depends on the source card's CURRENT stats - store the
+                    //expression so the descriptor re-evaluates it at match
+                    //time instead of freezing the parse-time value (#1125).
+                    if (comparisonExpression.size()
+                        && comparisonExpression.find_first_not_of("0123456789") != string::npos)
+                    {
+                        cd->dynamicManacostExpression = comparisonExpression;
+                        cd->dynamicManacostSource = card;
+                    }
                 }
                 else if (attribute.find("share!") != string::npos)
                 {


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Fixes #1125.

## Root cause

Dreadhorde Arcanist's trigger targets `*[instant;sorcery,manacost<=power]|mygraveyard` — but the `power` in the bracket criterion was evaluated **once**, by `WParsedInt` at TargetChooser construction, when the Arcanist sits at its printed 1 power. The resulting CardDescriptor carried a frozen numeric criterion, so pumping the Arcanist (the issue's two +1/+1 counters making it a 3/5) never widened the castable range: a mana value 3 Browbeat stayed unselectable forever.

## Fix

When the criterion expression after the comparison operator isn't a plain number, `CardDescriptor` now stores the expression and the source card, and re-evaluates it at match time (`currentManacostCriterion()`, consulted by both `match_or` and `match_and`). Plain numeric criteria are untouched — same single parse as before.

## Test

`generic/dreadhorde_arcanist_i1125.txt` reproduces the issue's exact scenario: pump the Arcanist to 3/5 with two Battlegrowths, attack, accept the trigger, and cast the mana value 3 Divination from the graveyard — asserting the two draws happened and the "exile it instead" rider fired. Verified load-bearing by counterfactual (re-freezing the criterion makes the test fail in the originally-reported way).

Full suite on the fork: 738 tests + 3 AI tests, 0 failures.