### PR TITLE
Card-list batches 1-50 (#1085): eighty-one entries triaged

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -73,6 +73,7 @@ generic/mobilized_district_i1085.txt
 generic/necrologia_i1085.txt
 generic/mwonvuli_beast_tracker_i1085.txt
 generic/misdirection_i1085.txt
+generic/mathas_fiend_seeker_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -17,6 +17,8 @@ generic/deathtouch.txt
 generic/adarkar_unicorn_upkeep_i1085.txt
 generic/adarkar_unicorn_mainphase_i1085.txt
 generic/aegar_spell_excess_i1085.txt
+generic/alrund_hand_buff_i1085.txt
+generic/archghoul_zombie_dies_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -44,6 +44,7 @@ generic/cursed_rack_i1085.txt
 generic/cytoplast_manipulator_i1085.txt
 generic/deadbridge_chant_i1085.txt
 generic/earthbind_i1085.txt
+generic/entrancing_lyre_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -37,6 +37,7 @@ generic/charm_peddler_i1085.txt
 generic/chatterfang_i1085.txt
 generic/chisei_i1085.txt
 generic/corpse_augur_i1085.txt
+generic/descendants_path_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -29,6 +29,7 @@ generic/bounty_of_the_luxa_i1085.txt
 generic/brightmare_i1085.txt
 generic/brothers_yamazaki_i1085.txt
 generic/brudiclad_token_i1085.txt
+generic/calamity_bearer_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -42,6 +42,7 @@ generic/curse_of_thirst_i1085.txt
 generic/curse_of_opulence_i1085.txt
 generic/cursed_rack_i1085.txt
 generic/cytoplast_manipulator_i1085.txt
+generic/deadbridge_chant_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -66,6 +66,7 @@ generic/infernal_darkness_i1085.txt
 generic/krovikan_plague_i1085.txt
 generic/livewire_lash_i1085.txt
 generic/living_death_i1085.txt
+generic/memorys_journey_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -35,6 +35,8 @@ generic/chalice_of_the_void_i1085.txt
 generic/chaos_wand_i1085.txt
 generic/charm_peddler_i1085.txt
 generic/chatterfang_i1085.txt
+generic/chisei_i1085.txt
+generic/collected_conjuring_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -36,7 +36,7 @@ generic/chaos_wand_i1085.txt
 generic/charm_peddler_i1085.txt
 generic/chatterfang_i1085.txt
 generic/chisei_i1085.txt
-generic/collected_conjuring_i1085.txt
+generic/corpse_augur_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -50,6 +50,7 @@ generic/extract_brain_i1085.txt
 generic/fertile_imagination_i1085.txt
 generic/first_slivers_chosen_i1085.txt
 generic/flay_essence_i1085.txt
+generic/forebears_blade_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -53,6 +53,7 @@ generic/flay_essence_i1085.txt
 generic/forebears_blade_i1085.txt
 generic/gift_of_the_gargantuan_i1085.txt
 generic/gor_muldrak_i1085.txt
+generic/grip_of_phyresis_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -33,6 +33,8 @@ generic/calamity_bearer_i1085.txt
 generic/call_death_dweller_i1085.txt
 generic/chalice_of_the_void_i1085.txt
 generic/chaos_wand_i1085.txt
+generic/charm_peddler_i1085.txt
+generic/chatterfang_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -19,6 +19,8 @@ generic/adarkar_unicorn_mainphase_i1085.txt
 generic/aegar_spell_excess_i1085.txt
 generic/alrund_hand_buff_i1085.txt
 generic/archghoul_zombie_dies_i1085.txt
+generic/arcums_weathervane_i1085.txt
+generic/athreos_shroud_veiled_coin_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -75,6 +75,7 @@ generic/mwonvuli_beast_tracker_i1085.txt
 generic/misdirection_i1085.txt
 generic/mathas_fiend_seeker_i1085.txt
 generic/lich_i1085.txt
+generic/lazotep_chancellor_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -51,6 +51,7 @@ generic/fertile_imagination_i1085.txt
 generic/first_slivers_chosen_i1085.txt
 generic/flay_essence_i1085.txt
 generic/forebears_blade_i1085.txt
+generic/gift_of_the_gargantuan_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -69,6 +69,7 @@ generic/living_death_i1085.txt
 generic/memorys_journey_i1085.txt
 generic/loreseekers_stone_i1085.txt
 generic/island_sanctuary_i1085.txt
+generic/mobilized_district_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -56,6 +56,7 @@ generic/gor_muldrak_i1085.txt
 generic/grip_of_phyresis_i1085.txt
 generic/gutter_grime_i1085.txt
 generic/hall_of_storm_giants_i1085.txt
+generic/heron_of_hope_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -45,6 +45,8 @@ generic/cytoplast_manipulator_i1085.txt
 generic/deadbridge_chant_i1085.txt
 generic/earthbind_i1085.txt
 generic/entrancing_lyre_i1085.txt
+generic/etherwrought_page_i1085.txt
+generic/extract_brain_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -47,6 +47,7 @@ generic/earthbind_i1085.txt
 generic/entrancing_lyre_i1085.txt
 generic/etherwrought_page_i1085.txt
 generic/extract_brain_i1085.txt
+generic/fertile_imagination_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -57,6 +57,7 @@ generic/grip_of_phyresis_i1085.txt
 generic/gutter_grime_i1085.txt
 generic/hall_of_storm_giants_i1085.txt
 generic/heron_of_hope_i1085.txt
+generic/hooded_hydra_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -49,6 +49,7 @@ generic/etherwrought_page_i1085.txt
 generic/extract_brain_i1085.txt
 generic/fertile_imagination_i1085.txt
 generic/first_slivers_chosen_i1085.txt
+generic/flay_essence_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -30,6 +30,8 @@ generic/brightmare_i1085.txt
 generic/brothers_yamazaki_i1085.txt
 generic/brudiclad_token_i1085.txt
 generic/calamity_bearer_i1085.txt
+generic/call_death_dweller_i1085.txt
+generic/chalice_of_the_void_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -41,7 +41,6 @@ generic/descendants_path_i1085.txt
 generic/curse_of_thirst_i1085.txt
 generic/curse_of_opulence_i1085.txt
 generic/cursed_rack_i1085.txt
-generic/cytoplast_manipulator_i1085.txt
 generic/deadbridge_chant_i1085.txt
 generic/earthbind_i1085.txt
 generic/entrancing_lyre_i1085.txt
@@ -66,6 +65,7 @@ generic/jaddi_lifestrider_i1085.txt
 generic/infernal_darkness_i1085.txt
 generic/krovikan_plague_i1085.txt
 generic/livewire_lash_i1085.txt
+generic/living_death_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -52,6 +52,7 @@ generic/first_slivers_chosen_i1085.txt
 generic/flay_essence_i1085.txt
 generic/forebears_blade_i1085.txt
 generic/gift_of_the_gargantuan_i1085.txt
+generic/gor_muldrak_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -58,6 +58,7 @@ generic/gutter_grime_i1085.txt
 generic/hall_of_storm_giants_i1085.txt
 generic/heron_of_hope_i1085.txt
 generic/hooded_hydra_i1085.txt
+generic/hot_soup_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -21,6 +21,8 @@ generic/alrund_hand_buff_i1085.txt
 generic/archghoul_zombie_dies_i1085.txt
 generic/arcums_weathervane_i1085.txt
 generic/athreos_shroud_veiled_coin_i1085.txt
+generic/azor_lockout_i1085.txt
+generic/bag_of_holding_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -60,6 +60,7 @@ generic/heron_of_hope_i1085.txt
 generic/hooded_hydra_i1085.txt
 generic/hot_soup_i1085.txt
 generic/idol_of_oblivion_i1085.txt
+generic/inevitable_end_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -64,6 +64,7 @@ generic/inevitable_end_i1085.txt
 generic/imprisoned_in_the_moon_i1085.txt
 generic/jaddi_lifestrider_i1085.txt
 generic/infernal_darkness_i1085.txt
+generic/krovikan_plague_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -65,6 +65,7 @@ generic/imprisoned_in_the_moon_i1085.txt
 generic/jaddi_lifestrider_i1085.txt
 generic/infernal_darkness_i1085.txt
 generic/krovikan_plague_i1085.txt
+generic/livewire_lash_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -61,6 +61,7 @@ generic/hooded_hydra_i1085.txt
 generic/hot_soup_i1085.txt
 generic/idol_of_oblivion_i1085.txt
 generic/inevitable_end_i1085.txt
+generic/imprisoned_in_the_moon_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -40,6 +40,8 @@ generic/corpse_augur_i1085.txt
 generic/descendants_path_i1085.txt
 generic/curse_of_thirst_i1085.txt
 generic/curse_of_opulence_i1085.txt
+generic/cursed_rack_i1085.txt
+generic/cytoplast_manipulator_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -63,6 +63,7 @@ generic/idol_of_oblivion_i1085.txt
 generic/inevitable_end_i1085.txt
 generic/imprisoned_in_the_moon_i1085.txt
 generic/jaddi_lifestrider_i1085.txt
+generic/infernal_darkness_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -38,6 +38,8 @@ generic/chatterfang_i1085.txt
 generic/chisei_i1085.txt
 generic/corpse_augur_i1085.txt
 generic/descendants_path_i1085.txt
+generic/curse_of_thirst_i1085.txt
+generic/curse_of_opulence_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -62,6 +62,7 @@ generic/hot_soup_i1085.txt
 generic/idol_of_oblivion_i1085.txt
 generic/inevitable_end_i1085.txt
 generic/imprisoned_in_the_moon_i1085.txt
+generic/jaddi_lifestrider_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -74,6 +74,7 @@ generic/necrologia_i1085.txt
 generic/mwonvuli_beast_tracker_i1085.txt
 generic/misdirection_i1085.txt
 generic/mathas_fiend_seeker_i1085.txt
+generic/lich_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -27,6 +27,8 @@ generic/battletide_alchemist_i1085.txt
 generic/betrayal_of_flesh_i1085.txt
 generic/bounty_of_the_luxa_i1085.txt
 generic/brightmare_i1085.txt
+generic/brothers_yamazaki_i1085.txt
+generic/brudiclad_token_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -32,6 +32,7 @@ generic/brudiclad_token_i1085.txt
 generic/calamity_bearer_i1085.txt
 generic/call_death_dweller_i1085.txt
 generic/chalice_of_the_void_i1085.txt
+generic/chaos_wand_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -67,6 +67,7 @@ generic/krovikan_plague_i1085.txt
 generic/livewire_lash_i1085.txt
 generic/living_death_i1085.txt
 generic/memorys_journey_i1085.txt
+generic/loreseekers_stone_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -72,6 +72,7 @@ generic/island_sanctuary_i1085.txt
 generic/mobilized_district_i1085.txt
 generic/necrologia_i1085.txt
 generic/mwonvuli_beast_tracker_i1085.txt
+generic/misdirection_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -43,6 +43,7 @@ generic/curse_of_opulence_i1085.txt
 generic/cursed_rack_i1085.txt
 generic/cytoplast_manipulator_i1085.txt
 generic/deadbridge_chant_i1085.txt
+generic/earthbind_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -68,6 +68,7 @@ generic/livewire_lash_i1085.txt
 generic/living_death_i1085.txt
 generic/memorys_journey_i1085.txt
 generic/loreseekers_stone_i1085.txt
+generic/island_sanctuary_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -70,6 +70,7 @@ generic/memorys_journey_i1085.txt
 generic/loreseekers_stone_i1085.txt
 generic/island_sanctuary_i1085.txt
 generic/mobilized_district_i1085.txt
+generic/necrologia_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -54,6 +54,7 @@ generic/forebears_blade_i1085.txt
 generic/gift_of_the_gargantuan_i1085.txt
 generic/gor_muldrak_i1085.txt
 generic/grip_of_phyresis_i1085.txt
+generic/gutter_grime_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -71,6 +71,7 @@ generic/loreseekers_stone_i1085.txt
 generic/island_sanctuary_i1085.txt
 generic/mobilized_district_i1085.txt
 generic/necrologia_i1085.txt
+generic/mwonvuli_beast_tracker_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -55,6 +55,7 @@ generic/gift_of_the_gargantuan_i1085.txt
 generic/gor_muldrak_i1085.txt
 generic/grip_of_phyresis_i1085.txt
 generic/gutter_grime_i1085.txt
+generic/hall_of_storm_giants_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,10 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/adarkar_unicorn_upkeep_i1085.txt
+generic/adarkar_unicorn_mainphase_i1085.txt
+generic/aegar_spell_excess_i1085.txt
+ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -23,6 +23,8 @@ generic/arcums_weathervane_i1085.txt
 generic/athreos_shroud_veiled_coin_i1085.txt
 generic/azor_lockout_i1085.txt
 generic/bag_of_holding_i1085.txt
+generic/battletide_alchemist_i1085.txt
+generic/betrayal_of_flesh_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -25,6 +25,8 @@ generic/azor_lockout_i1085.txt
 generic/bag_of_holding_i1085.txt
 generic/battletide_alchemist_i1085.txt
 generic/betrayal_of_flesh_i1085.txt
+generic/bounty_of_the_luxa_i1085.txt
+generic/brightmare_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -59,6 +59,7 @@ generic/hall_of_storm_giants_i1085.txt
 generic/heron_of_hope_i1085.txt
 generic/hooded_hydra_i1085.txt
 generic/hot_soup_i1085.txt
+generic/idol_of_oblivion_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -48,6 +48,7 @@ generic/entrancing_lyre_i1085.txt
 generic/etherwrought_page_i1085.txt
 generic/extract_brain_i1085.txt
 generic/fertile_imagination_i1085.txt
+generic/first_slivers_chosen_i1085.txt
 ai/death_wind_self_target_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt

--- a/projects/mtg/bin/Res/test/ai/death_wind_self_target_i1085.txt
+++ b/projects/mtg/bin/Res/test/ai/death_wind_self_target_i1085.txt
@@ -1,0 +1,24 @@
+#Bug (from the #1085 meta-list): "AI uses Death Wind on its creatures"
+# https://github.com/WagicProject/wagic/issues/1085
+#The card script constrains AI casts to opponentbattlefield; the engine
+#also classifies targeting by the ability's effect since #1167.
+FORCEABILITY
+AICALLS 5
+SEED 12345
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:grizzly bears,leaden myr,leaden myr,leaden myr
+hand:death wind
+[PLAYER2]
+inplay:raging goblin
+[DO]
+ai
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:grizzly bears,leaden myr,leaden myr,leaden myr
+graveyard:death wind
+[PLAYER2]
+graveyard:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/adarkar_unicorn_mainphase_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/adarkar_unicorn_mainphase_i1085.txt
@@ -1,0 +1,17 @@
+#Companion to adarkar_unicorn_upkeep: outside the upkeep the mana
+#abilities must not be available.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:adarkar unicorn
+[PLAYER2]
+[DO]
+adarkar unicorn
+choice 0
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:adarkar unicorn
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/adarkar_unicorn_upkeep_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/adarkar_unicorn_upkeep_i1085.txt
@@ -1,0 +1,19 @@
+#Bug (from the #1085 meta-list): Adarkar Unicorn's mana is only for
+#cumulative upkeep costs (paid during your upkeep), but the script
+#offered it as an unrestricted mana source.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+UPKEEP
+[PLAYER1]
+inplay:adarkar unicorn
+[PLAYER2]
+[DO]
+adarkar unicorn
+choice 0
+[ASSERT]
+UPKEEP
+[PLAYER1]
+inplay:adarkar unicorn
+manapool:{U}
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/aegar_spell_excess_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/aegar_spell_excess_i1085.txt
@@ -1,0 +1,29 @@
+#Bug (from the #1085 meta-list): Aegar, the Freezing Flame "doesn't
+#seem to work with instants and sorceries" - excess spell damage to an
+#opposing creature should draw a card.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:503816
+hand:shock
+library:millstone,juggernaut
+manapool:{R}
+[PLAYER2]
+inplay:raging goblin
+[DO]
+shock
+raging goblin
+goto firstmain
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:503816
+graveyard:shock
+hand:*
+library:*
+[PLAYER2]
+graveyard:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/alrund_hand_buff_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/alrund_hand_buff_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Alrund, God of the Cosmos (no symptom given).
+#Pins the static buff: +1/+1 for each card in your hand. With three
+#cards in hand Alrund is 4/4 and deals 4 unblocked combat damage.
+#(Referenced by set id 503646: the name contains a comma, which the
+#test zone lists split on.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:503646
+hand:millstone,juggernaut,ornithopter
+[PLAYER2]
+[DO]
+goto attackers
+503646
+next
+next
+next
+[ASSERT]
+COMBATEND
+[PLAYER1]
+inplay:503646
+hand:millstone,juggernaut,ornithopter
+[PLAYER2]
+life:16
+[END]

--- a/projects/mtg/bin/Res/test/generic/archghoul_zombie_dies_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/archghoul_zombie_dies_i1085.txt
@@ -1,0 +1,29 @@
+#From the #1085 meta-list: Archghoul of Thraben. When another Zombie
+#you control dies, look at the top card; a Zombie card may go to hand.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:archghoul of thraben,walking corpse
+hand:shock
+library:millstone,gravecrawler
+manapool:{R}
+[PLAYER2]
+[DO]
+shock
+walking corpse
+goto firstmain
+goto firstmain
+goto firstmain
+choice 0
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:archghoul of thraben
+graveyard:shock,walking corpse
+hand:gravecrawler
+library:millstone
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/arcums_weathervane_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/arcums_weathervane_i1085.txt
@@ -1,0 +1,30 @@
+#From the #1085 meta-list: Arcum's Weathervane (no symptom given).
+#Removing Snow from a Snow-Covered Mountain must make Skred deal 0:
+#the goblin survives only if the Weathervane actually stripped the
+#Snow supertype.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:arcum's weathervane,snow-covered mountain
+hand:skred
+manapool:{2}{R}
+[PLAYER2]
+inplay:raging goblin
+[DO]
+arcum's weathervane
+choice 0
+snow-covered mountain
+skred
+raging goblin
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:arcum's weathervane,snow-covered mountain
+graveyard:skred
+manapool:{0}
+[PLAYER2]
+inplay:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/athreos_shroud_veiled_coin_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/athreos_shroud_veiled_coin_i1085.txt
@@ -1,0 +1,29 @@
+#From the #1085 meta-list: "Athreos, Shroud-Veiled creature return".
+#Works: the end-step coin prompt must be accepted (choice 0) before
+#clicking the target; a coined creature that dies then returns to the
+#battlefield under Athreos's controller's control.
+#(Card by set id 676085: the name contains a comma.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:676085,iron myr
+hand:shock
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+goto end
+choice 0
+grizzly bears
+iron myr
+shock
+grizzly bears
+goto cleanup
+goto cleanup
+[ASSERT]
+CLEANUP
+[PLAYER1]
+inplay:676085,iron myr,grizzly bears
+graveyard:shock
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/azor_lockout_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/azor_lockout_i1085.txt
@@ -1,0 +1,30 @@
+#From the #1085 meta-list: Azor, the Lawbringer (no symptom given).
+#When Azor enters, each opponent can't cast instants/sorceries during
+#that player's next turn: the opponent's Shock must stay in hand.
+#(Card by set id 439811: the name contains a comma.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:439811
+manapool:{2}{W}{W}{U}{U}
+[PLAYER2]
+inplay:iron myr
+hand:shock
+[DO]
+439811
+goto end
+goto firstmain
+iron myr
+shock
+p1
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:439811
+[PLAYER2]
+inplay:iron myr
+hand:shock
+[END]

--- a/projects/mtg/bin/Res/test/generic/bag_of_holding_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/bag_of_holding_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Bag of Holding (no symptom given).
+#Loot with the bag: the discarded card must end up exiled (not in the
+#graveyard), tracked for the later return ability.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:bag of holding
+hand:juggernaut
+library:millstone
+manapool:{2}
+[PLAYER2]
+[DO]
+bag of holding
+choice 0
+juggernaut
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:bag of holding
+hand:millstone
+exile:juggernaut
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/battletide_alchemist_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/battletide_alchemist_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Battletide Alchemist (no symptom given).
+#With one Cleric (itself), activating the prevention shields 1 damage:
+#a self-targeted Shock deals only 1.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:battletide alchemist
+hand:shock
+manapool:{R}
+[PLAYER2]
+[DO]
+battletide alchemist
+choice 0
+shock
+p1
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:battletide alchemist
+graveyard:shock
+life:19
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/betrayal_of_flesh_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/betrayal_of_flesh_i1085.txt
@@ -1,0 +1,23 @@
+#From the #1085 meta-list: Betrayal of Flesh (no symptom given).
+#Base mode: destroy target creature.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:betrayal of flesh
+manapool:{5}{B}
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+betrayal of flesh
+choice 0
+grizzly bears
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:betrayal of flesh
+[PLAYER2]
+graveyard:grizzly bears
+[END]

--- a/projects/mtg/bin/Res/test/generic/bounty_of_the_luxa_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/bounty_of_the_luxa_i1085.txt
@@ -1,0 +1,28 @@
+#From the #1085 meta-list: Bounty of the Luxa (no symptom given).
+#First upkeep cycle: flood counter + draw. Next: counters off, add
+#{1}{G}{U}. Asserted at the second of the controller's main phases.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:bounty of the luxa
+library:millstone,juggernaut
+[PLAYER2]
+[DO]
+goto firstmain
+goto end
+goto firstmain
+choice 0
+goto end
+goto firstmain
+goto end
+goto firstmain
+choice 0
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:bounty of the luxa
+manapool:{C}{G}{U}
+hand:*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/brightmare_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/brightmare_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Brightmare (no symptom given).
+#ETB: tap up to one target creature, gain life equal to its power.
+#Tapping the opponent's Grizzly Bears gains 2.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:brightmare
+manapool:{2}{W}
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+brightmare
+choice 0
+grizzly bears
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:brightmare
+life:22
+[PLAYER2]
+inplay:grizzly bears
+tappedinplay:1
+[END]

--- a/projects/mtg/bin/Res/test/generic/brothers_yamazaki_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/brothers_yamazaki_i1085.txt
@@ -1,0 +1,22 @@
+#From the #1085 meta-list: Brothers Yamazaki (no symptom given).
+#Exactly two may coexist (legend rule waived) and each gives the
+#other +2/+2 and haste: one attacks unblocked for 4.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:brothers yamazaki,brothers yamazaki
+[PLAYER2]
+[DO]
+goto attackers
+brothers yamazaki
+next
+next
+next
+[ASSERT]
+COMBATEND
+[PLAYER1]
+inplay:brothers yamazaki,brothers yamazaki
+[PLAYER2]
+life:16
+[END]

--- a/projects/mtg/bin/Res/test/generic/brudiclad_token_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/brudiclad_token_i1085.txt
@@ -1,0 +1,22 @@
+#From the #1085 meta-list: Brudiclad, Telchor Engineer (no symptom
+#given). At the beginning of combat on your turn he creates a 2/1
+#Myr token. (Card by set id 489866: the name contains a comma.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:489866
+[PLAYER2]
+[DO]
+goto combatbegins
+choice 0
+phyrexian myr
+goto attackers
+goto end
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:489866,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/calamity_bearer_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/calamity_bearer_i1085.txt
@@ -1,0 +1,22 @@
+#From the #1085 meta-list: Calamity Bearer (no symptom given).
+#A Giant source you control deals double damage: an unblocked Hill
+#Giant (3/3) hits the player for 6 with the Bearer out.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:calamity bearer,hill giant
+[PLAYER2]
+[DO]
+goto attackers
+hill giant
+next
+next
+next
+[ASSERT]
+COMBATEND
+[PLAYER1]
+inplay:calamity bearer,hill giant
+[PLAYER2]
+life:14
+[END]

--- a/projects/mtg/bin/Res/test/generic/call_death_dweller_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/call_death_dweller_i1085.txt
@@ -1,0 +1,27 @@
+#From the #1085 meta-list: Call of the Death-Dweller (no symptom
+#given). Simple path: return one mana-value-2 creature from the
+#graveyard to the battlefield.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:call of the death-dweller
+graveyard:grizzly bears
+manapool:{2}{B}
+[PLAYER2]
+[DO]
+call of the death-dweller
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:grizzly bears
+graveyard:call of the death-dweller
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/chalice_of_the_void_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/chalice_of_the_void_i1085.txt
@@ -1,0 +1,28 @@
+#From the #1085 meta-list: "Chalice of the Void counters".
+#Cast with X=1 (two mana), it counters mana-value-1 spells: the
+#controller's own Shock fizzles and the opponent stays at 20.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:chalice of the void,shock
+manapool:{2}{R}
+[PLAYER2]
+[DO]
+chalice of the void
+choice 2
+shock
+p2
+goto firstmain
+goto firstmain
+choice 0
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:chalice of the void
+graveyard:shock
+[PLAYER2]
+life:20
+[END]

--- a/projects/mtg/bin/Res/test/generic/chaos_wand_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/chaos_wand_i1085.txt
@@ -1,0 +1,31 @@
+#From the #1085 meta-list: Chaos Wand (no symptom given).
+#Reveal from the opponent's library until an instant/sorcery, cast it
+#free: the wand digs past Juggernaut, finds Shock, casts it at the
+#opponent; the leftover goes to the bottom.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:chaos wand
+manapool:{4}
+[PLAYER2]
+library:shock,juggernaut
+[DO]
+chaos wand
+choice 0
+shock
+goto firstmain
+goto firstmain
+choice 0
+p2
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:chaos wand
+[PLAYER2]
+graveyard:shock
+library:juggernaut
+life:18
+[END]

--- a/projects/mtg/bin/Res/test/generic/charm_peddler_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/charm_peddler_i1085.txt
@@ -1,0 +1,27 @@
+#From the #1085 meta-list: Charm Peddler (no symptom given).
+#{W},{T},Discard: prevent the next damage to target creature. The
+#shielded Grizzly Bears survive a Shock.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:charm peddler,grizzly bears
+hand:juggernaut,shock
+manapool:{W}{R}
+[PLAYER2]
+[DO]
+charm peddler
+choice 0
+juggernaut
+grizzly bears
+shock
+grizzly bears
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:charm peddler,grizzly bears
+graveyard:juggernaut,shock
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/chatterfang_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/chatterfang_i1085.txt
@@ -1,0 +1,23 @@
+#From the #1085 meta-list: Chatterfang, Squirrel General (no symptom
+#given). Whenever tokens enter under your control, create that many
+#1/1 Squirrels: Krenko's Command's two Goblins bring two Squirrels -
+#five creatures total. (Card by set id 670901: comma in the name.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:670901
+hand:krenko's command
+manapool:{1}{R}
+[PLAYER2]
+[DO]
+krenko's command
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:670901,*,*,*,*
+graveyard:krenko's command
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/chisei_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/chisei_i1085.txt
@@ -1,0 +1,29 @@
+#From the #1085 meta-list: Chisei, Heart of Oceans (no symptom given).
+#At your upkeep: remove a counter from a permanent you control or
+#sacrifice Chisei. With a +1/+1 counter available, removing it keeps
+#Chisei alive. (Card by set id; comma in the name.)
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:74096,grizzly bears
+hand:battlegrowth
+manapool:{G}
+[PLAYER2]
+[DO]
+battlegrowth
+grizzly bears
+goto upkeep
+goto end
+goto upkeep
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:74096,grizzly bears
+graveyard:battlegrowth
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/collected_conjuring_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/collected_conjuring_i1085.txt
@@ -1,0 +1,31 @@
+#From the #1085 meta-list: Collected Conjuring (no symptom given).
+#Exile the top six, cast up to two cheap sorceries free: two copies
+#of Krenko's Command yield four Goblin tokens.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:collected conjuring
+library:millstone,ornithopter,mox pearl,juggernaut,krenko's command,divination,darksteel citadel
+manapool:{2}{U}{R}
+[PLAYER2]
+[DO]
+collected conjuring
+goto firstmain
+goto firstmain
+choice 0
+krenko's command
+goto firstmain
+goto firstmain
+divination
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:*,*
+hand:*,*
+library:*,*,*
+graveyard:collected conjuring,krenko's command,divination
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/collected_conjuring_i1085.txt.disabled
+++ b/projects/mtg/bin/Res/test/generic/collected_conjuring_i1085.txt.disabled
@@ -13,11 +13,17 @@ manapool:{2}{U}{R}
 collected conjuring
 goto firstmain
 goto firstmain
+goto firstmain
+goto firstmain
 choice 0
 krenko's command
 goto firstmain
 goto firstmain
+goto firstmain
+goto firstmain
 divination
+goto firstmain
+goto firstmain
 goto secondmain
 goto secondmain
 [ASSERT]

--- a/projects/mtg/bin/Res/test/generic/corpse_augur_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/corpse_augur_i1085.txt
@@ -1,0 +1,30 @@
+#From the #1085 meta-list: Corpse Augur (no symptom given).
+#On death: draw X, lose X, X = creatures in target player's graveyard.
+#Choosing the controller with 3 dead creatures (including the Augur
+#itself): draw 3, lose 3.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:corpse augur
+hand:shock
+graveyard:walking corpse,juggernaut
+library:millstone,ornithopter,mox pearl
+manapool:{R}
+[PLAYER2]
+[DO]
+shock
+corpse augur
+goto firstmain
+goto firstmain
+choice 1
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:walking corpse,juggernaut,corpse augur,shock
+hand:*,*,*
+life:17
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/curse_of_opulence_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/curse_of_opulence_i1085.txt
@@ -1,0 +1,27 @@
+#From the #1085 meta-list: "Curse of Opulence and similar curses".
+#Attacking the cursed player creates a Gold token for the attacker.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:grizzly bears
+hand:curse of opulence
+manapool:{R}
+[PLAYER2]
+[DO]
+curse of opulence
+p2
+goto attackers
+goto end
+goto attackers
+grizzly bears
+next
+next
+next
+[ASSERT]
+COMBATEND
+[PLAYER1]
+inplay:grizzly bears,curse of opulence,*
+[PLAYER2]
+life:18
+[END]

--- a/projects/mtg/bin/Res/test/generic/curse_of_thirst_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/curse_of_thirst_i1085.txt
@@ -1,0 +1,23 @@
+#From the #1085 meta-list: Curse of Thirst (no symptom given).
+#At the cursed player's upkeep it deals damage equal to their curse
+#count: the opponent takes 1 at their next upkeep.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+hand:curse of thirst
+manapool:{4}{B}
+[PLAYER2]
+[DO]
+curse of thirst
+p2
+goto upkeep
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:curse of thirst
+[PLAYER2]
+life:19
+[END]

--- a/projects/mtg/bin/Res/test/generic/cursed_rack_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/cursed_rack_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Cursed Rack (no symptom given).
+#The chosen opponent's maximum hand size is four: with six cards they
+#discard two at their cleanup.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:cursed rack
+[PLAYER2]
+hand:millstone,juggernaut,ornithopter,mox pearl,darksteel citadel,leaden myr
+[DO]
+goto cleanup
+goto firstmain
+goto cleanup
+millstone
+juggernaut
+goto upkeep
+goto upkeep
+[ASSERT]
+UPKEEP
+[PLAYER1]
+inplay:cursed rack
+[PLAYER2]
+hand:ornithopter,mox pearl,darksteel citadel,leaden myr
+graveyard:millstone,juggernaut
+[END]

--- a/projects/mtg/bin/Res/test/generic/cytoplast_manipulator_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/cytoplast_manipulator_i1085.txt
@@ -13,8 +13,12 @@ inplay:grizzly bears
 [DO]
 battlegrowth
 grizzly bears
+goto firstmain
+goto firstmain
 cytoplast manipulator
 grizzly bears
+goto firstmain
+goto firstmain
 goto secondmain
 goto secondmain
 [ASSERT]

--- a/projects/mtg/bin/Res/test/generic/cytoplast_manipulator_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/cytoplast_manipulator_i1085.txt
@@ -1,0 +1,27 @@
+#From the #1085 meta-list: Cytoplast Manipulator (no symptom given).
+#{U},{T}: gain control of target creature with a +1/+1 counter -
+#Battlegrowth marks the opponent's bears, the Manipulator steals them.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:cytoplast manipulator
+hand:battlegrowth
+manapool:{G}{U}
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+battlegrowth
+grizzly bears
+cytoplast manipulator
+grizzly bears
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:cytoplast manipulator,grizzly bears
+graveyard:battlegrowth
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/deadbridge_chant_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/deadbridge_chant_i1085.txt
@@ -1,0 +1,28 @@
+#From the #1085 meta-list: Deadbridge Chant (no symptom given).
+#ETB mills ten; at upkeep a random graveyard card returns - creature
+#to the battlefield. With all ten milled cards being creatures the
+#outcome is deterministic: one comes back.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+hand:deadbridge chant
+library:darksteel citadel,walking corpse,walking corpse,walking corpse,walking corpse,walking corpse,runeclaw bear,runeclaw bear,runeclaw bear,runeclaw bear,runeclaw bear
+manapool:{4}{B}{G}
+[PLAYER2]
+[DO]
+deadbridge chant
+goto upkeep
+goto end
+goto upkeep
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:deadbridge chant,*
+hand:*
+graveyard:*,*,*,*,*,*,*,*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/descendants_path_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/descendants_path_i1085.txt
@@ -1,0 +1,29 @@
+#From the #1085 meta-list: "Descendants' Path, not casting".
+#At upkeep, reveal the top card; a creature sharing a type with one
+#you control may be cast free: Runeclaw Bear shares Bear with Grizzly
+#Bears and should hit the battlefield.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:descendants' path,grizzly bears
+library:millstone,runeclaw bear
+[PLAYER2]
+[DO]
+goto upkeep
+goto end
+goto upkeep
+choice 0
+runeclaw bear
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:descendants' path,grizzly bears,runeclaw bear
+hand:*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/earthbind_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/earthbind_i1085.txt
@@ -1,0 +1,23 @@
+#From the #1085 meta-list: Earthbind (no symptom given).
+#Enchanting a flyer deals it 2: the 2/2 Wind Drake dies and the aura
+#follows it to the graveyard.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:earthbind
+manapool:{R}
+[PLAYER2]
+inplay:wind drake
+[DO]
+earthbind
+wind drake
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:earthbind
+[PLAYER2]
+graveyard:wind drake
+[END]

--- a/projects/mtg/bin/Res/test/generic/entrancing_lyre_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/entrancing_lyre_i1085.txt
@@ -1,0 +1,26 @@
+#From the #1085 meta-list: Entrancing Lyre (no symptom given).
+#{X},{T}: tap target creature with power <= X; it stays tapped while
+#the Lyre stays tapped. The X=2 mode taps Grizzly Bears.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:entrancing lyre
+manapool:{2}
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+entrancing lyre
+choice 2
+grizzly bears
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:entrancing lyre
+tappedinplay:1
+[PLAYER2]
+inplay:grizzly bears
+tappedinplay:1
+[END]

--- a/projects/mtg/bin/Res/test/generic/etherwrought_page_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/etherwrought_page_i1085.txt
@@ -1,0 +1,22 @@
+#From the #1085 meta-list: Etherwrought Page (no symptom given).
+#Upkeep modal: mode one gains 2 life.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+SECONDMAIN
+[PLAYER1]
+inplay:etherwrought page
+[PLAYER2]
+[DO]
+goto upkeep
+goto end
+goto upkeep
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:etherwrought page
+life:22
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/extract_brain_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/extract_brain_i1085.txt
@@ -1,0 +1,32 @@
+#From the #1085 meta-list: Extract Brain (no symptom given).
+#Cast with X=1: look at a card from the opponent's hand and cast a
+#spell from among them free.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:extract brain
+manapool:{1}{U}{B}
+[PLAYER2]
+hand:shock,millstone
+[DO]
+extract brain
+choice 1
+goto firstmain
+goto firstmain
+choice 0
+shock
+goto firstmain
+goto firstmain
+p2
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:extract brain
+[PLAYER2]
+hand:millstone
+graveyard:shock
+life:18
+[END]

--- a/projects/mtg/bin/Res/test/generic/fertile_imagination_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/fertile_imagination_i1085.txt
@@ -1,0 +1,60 @@
+#Fertile Imagination (#1085 list): choose Creature via the merged type menu (choice 2 = third
+#entry, line order artifact/battle/creature/...), opponent reveals, 2 Saprolings per creature
+#revealed (transforms-granted one-shot pays out to the caster). The other 8 type-prompts are
+#mandatory (may-must) and each reveals+returns one card.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{G}{G}
+hand:fertile imagination
+[PLAYER2]
+hand:grizzly bears,hill giant
+[DO]
+fertile imagination
+goto firstmain
+goto firstmain
+choice 2
+grizzly bears
+hill giant
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+graveyard:fertile imagination
+inplay:*,*,*,*
+[PLAYER2]
+hand:grizzly bears,hill giant
+[END]

--- a/projects/mtg/bin/Res/test/generic/first_slivers_chosen_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/first_slivers_chosen_i1085.txt
@@ -1,0 +1,21 @@
+#First Sliver's Chosen (#1085): slivers you control gain exalted. Metallic Sliver attacks
+#alone: chosen's own exalted (+1) plus the granted exalted on the attacker (+1) = 1/1 swings
+#as 3/3 unblocked -> opponent at 17.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:first sliver's chosen,metallic sliver
+[PLAYER2]
+[DO]
+goto attackers
+metallic sliver
+next
+choice 0
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:first sliver's chosen,metallic sliver
+[PLAYER2]
+life:17
+[END]

--- a/projects/mtg/bin/Res/test/generic/flay_essence_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/flay_essence_i1085.txt
@@ -1,0 +1,25 @@
+#Flay Essence (#1085): exile target creature, gain life equal to its counters.
+#Fertilid enters with two +1/+1 counters -> exiled, caster gains 2 (life 22).
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{1}{B}{B}
+hand:flay essence
+[PLAYER2]
+inplay:fertilid
+[DO]
+flay essence
+goto firstmain
+goto firstmain
+choice 0
+fertilid
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:22
+graveyard:flay essence
+[PLAYER2]
+exile:fertilid
+[END]

--- a/projects/mtg/bin/Res/test/generic/forebears_blade_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/forebears_blade_i1085.txt
@@ -1,0 +1,36 @@
+#Forebear's Blade (#1085): equipped creature dies -> attach to target creature you control.
+#Equip bears, shock bears (2/2 dies), re-attach prompt -> hill giant; giant attacks
+#unblocked with +3/+0 = 6 damage (life 14). If the granted re-attach is inert the giant
+#swings for 3 (life 17).
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{3}{R}
+inplay:forebear's blade,grizzly bears,hill giant
+hand:shock
+[PLAYER2]
+[DO]
+forebear's blade
+grizzly bears
+goto firstmain
+goto firstmain
+shock
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+hill giant
+goto firstmain
+goto firstmain
+goto attackers
+hill giant
+next
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:forebear's blade,hill giant
+graveyard:shock,grizzly bears
+[PLAYER2]
+life:14
+[END]

--- a/projects/mtg/bin/Res/test/generic/gift_of_the_gargantuan_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/gift_of_the_gargantuan_i1085.txt
@@ -1,0 +1,30 @@
+#Gift of the Gargantuan (#1085): look at top 4, reveal a creature and/or a land to hand,
+#rest to bottom. Library lists BOTTOM-TO-TOP: top 4 = citadel(top), bears, juggernaut,
+#millstone. Take bears (creature) then citadel (land) via the nested second-type choice.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{G}
+hand:gift of the gargantuan
+library:millstone,juggernaut,grizzly bears,darksteel citadel
+[PLAYER2]
+[DO]
+gift of the gargantuan
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+darksteel citadel
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+hand:grizzly bears,darksteel citadel
+graveyard:gift of the gargantuan
+library:*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/gor_muldrak_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/gor_muldrak_i1085.txt
@@ -1,0 +1,21 @@
+#Gor Muldrak, Amphinologist (#1085; comma name -> set id 497797): at the beginning of my
+#end step, each player with the fewest creatures creates a 4/3 Salamander Warrior. One
+#creature each side = tie -> both players get one.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:497797
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+goto end
+choice 0
+goto end
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:497797,*
+[PLAYER2]
+inplay:grizzly bears,*
+[END]

--- a/projects/mtg/bin/Res/test/generic/grip_of_phyresis_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/grip_of_phyresis_i1085.txt
@@ -1,0 +1,29 @@
+#Grip of Phyresis (#1085): gain control of target Equipment, create a 0/0 Germ, attach the
+#stolen Equipment to it. Accorder's Shield (+0/+3) keeps the germ alive at 0/3.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{U}
+hand:grip of phyresis
+[PLAYER2]
+inplay:accorder's shield
+[DO]
+grip of phyresis
+accorder's shield
+goto firstmain
+goto firstmain
+choice 0
+accorder's shield
+goto firstmain
+goto firstmain
+choice 0
+phyrexian germ
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:accorder's shield,*
+graveyard:grip of phyresis
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/gutter_grime_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/gutter_grime_i1085.txt
@@ -1,0 +1,25 @@
+#Gutter Grime (#1085): nontoken creature dies -> slime counter + Ooze token with P/T =
+#slime counters. The 0/0 ooze only survives if the counter-scaled lord (+1/+1 at one
+#slime counter) applies - its presence on the battlefield IS the assertion.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{R}
+inplay:gutter grime,grizzly bears
+hand:shock
+[PLAYER2]
+[DO]
+shock
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:gutter grime,*
+graveyard:shock,grizzly bears
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/hall_of_storm_giants_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/hall_of_storm_giants_i1085.txt
@@ -1,0 +1,37 @@
+#Hall of Storm Giants (#1085): {5}{U}: becomes a 7/7 Giant with ward until end of turn.
+#Myrs pay the cost on a later turn; the animated hall attacks unblocked for 7 (life 13).
+#NB: clicking a permanent with activated abilities at attackers opens a menu -
+#choice 0 = "Attack Player".
+[INIT]
+firstmain
+[PLAYER1]
+inplay:hall of storm giants,gold myr,copper myr,silver myr,iron myr,leaden myr,palladium myr
+[PLAYER2]
+[DO]
+goto end
+goto firstmain
+goto end
+goto firstmain
+gold myr
+copper myr
+silver myr
+iron myr
+leaden myr
+palladium myr
+hall of storm giants
+choice 1
+goto firstmain
+goto firstmain
+goto attackers
+hall of storm giants
+choice 0
+next
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:hall of storm giants,gold myr,copper myr,silver myr,iron myr,leaden myr,palladium myr
+tappedinplay:7
+[PLAYER2]
+life:13
+[END]

--- a/projects/mtg/bin/Res/test/generic/heron_of_hope_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/heron_of_hope_i1085.txt
@@ -1,0 +1,25 @@
+#Heron of Hope (#1085): lifefaker (gain +1 extra). Activate {1}{W} lifelink, attack
+#unblocked for 2: opponent 18, controller gains 2+1=3 -> 23.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{1}{W}
+inplay:heron of hope
+[PLAYER2]
+[DO]
+heron of hope
+choice 0
+goto firstmain
+goto firstmain
+goto attackers
+heron of hope
+next
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+life:23
+inplay:heron of hope
+[PLAYER2]
+life:18
+[END]

--- a/projects/mtg/bin/Res/test/generic/hooded_hydra_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/hooded_hydra_i1085.txt
@@ -1,0 +1,28 @@
+#Hooded Hydra (#1085): enters with X +1/+1 counters; dies -> a 1/1 Snake per counter.
+#Cast with X=2 (choice 2 on the X menu), shock it (2 dmg kills the 2/2), expect 2 snakes.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{G}{G}{R}
+hand:hooded hydra,shock
+[PLAYER2]
+[DO]
+hooded hydra
+choice 0
+choice 2
+goto firstmain
+goto firstmain
+shock
+hooded hydra
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+graveyard:shock,hooded hydra
+inplay:*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/hot_soup_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/hot_soup_i1085.txt
@@ -1,0 +1,29 @@
+#Hot Soup (#1085): equipped creature is destroyed whenever it's dealt damage.
+#Equip the 3/3 hill giant, shock it for 2 (survives toughness-wise) - the taught
+#@damaged trigger destroys it anyway.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{3}{R}
+inplay:hot soup,hill giant
+hand:shock
+[PLAYER2]
+[DO]
+hot soup
+hill giant
+goto firstmain
+goto firstmain
+shock
+hill giant
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:hot soup
+graveyard:shock,hill giant
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/idol_of_oblivion_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/idol_of_oblivion_i1085.txt
@@ -1,0 +1,31 @@
+#Idol of Oblivion (#1085): created a token this turn -> idol gains "{T}: draw a card"
+#until end of turn (transforms-granted ACTIVATED ability). Raise the Alarm makes the
+#tokens, then tapping the idol draws: hand 1, library 1, idol tapped.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{1}{W}
+inplay:idol of oblivion
+hand:raise the alarm
+library:millstone,juggernaut
+[PLAYER2]
+[DO]
+raise the alarm
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+idol of oblivion
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+hand:juggernaut
+graveyard:raise the alarm
+inplay:idol of oblivion,*,*
+library:millstone
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/imprisoned_in_the_moon_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/imprisoned_in_the_moon_i1085.txt
@@ -1,0 +1,25 @@
+#Imprisoned in the Moon (#1085): enchanted permanent becomes a colorless land with
+#"{T}: Add {C}" and loses other types/abilities. Enchant own hill giant, tap it: pool {C}.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{U}
+inplay:hill giant
+hand:imprisoned in the moon
+[PLAYER2]
+[DO]
+imprisoned in the moon
+hill giant
+goto firstmain
+goto firstmain
+hill giant
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+manapool:{C}
+inplay:imprisoned in the moon,hill giant
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/inevitable_end_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/inevitable_end_i1085.txt
@@ -1,0 +1,29 @@
+#Inevitable End (#1085): aura teaches "at the beginning of your upkeep, sacrifice a
+#creature" to the enchanted creature. Enchant the opponent's hill giant; at the
+#opponent's upkeep they sacrifice the grizzly bears.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{B}
+hand:inevitable end
+[PLAYER2]
+inplay:hill giant,grizzly bears
+[DO]
+inevitable end
+hill giant
+goto firstmain
+goto firstmain
+goto end
+goto upkeep
+choice 0
+grizzly bears
+goto upkeep
+goto upkeep
+[ASSERT]
+UPKEEP
+[PLAYER1]
+inplay:inevitable end
+[PLAYER2]
+inplay:hill giant
+graveyard:grizzly bears
+[END]

--- a/projects/mtg/bin/Res/test/generic/infernal_darkness_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/infernal_darkness_i1085.txt
@@ -1,0 +1,19 @@
+#Infernal Darkness (#1085): lands produce {B} instead of their own mana.
+#Tapping Darksteel Citadel (normally {C}) must yield {B}.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:infernal darkness,darksteel citadel
+[PLAYER2]
+[DO]
+darksteel citadel
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+manapool:{B}
+inplay:infernal darkness,darksteel citadel
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/island_sanctuary_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/island_sanctuary_i1085.txt
@@ -1,0 +1,29 @@
+#Island Sanctuary (#1085): replace your draw -> skip it and become unattackable except
+#by flying/islandwalk until your next turn. Skip the turn-3 draw; the opponent's bears
+#cannot attack on their turn 4 (life stays 20; without the skip the attack deals 2).
+[INIT]
+firstmain
+[PLAYER1]
+inplay:island sanctuary
+library:millstone,juggernaut
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+goto end
+goto end
+goto draw
+choice 0
+goto end
+goto attackers
+grizzly bears
+next
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+life:20
+inplay:island sanctuary
+library:millstone,juggernaut
+[PLAYER2]
+inplay:grizzly bears
+[END]

--- a/projects/mtg/bin/Res/test/generic/jaddi_lifestrider_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/jaddi_lifestrider_i1085.txt
@@ -1,0 +1,28 @@
+#Jaddi Lifestrider (#1085): ETB - tap any number of your creatures, gain 2 per tap.
+#The <anyamount> chooser is CONFIRMED BY RE-CLICKING THE SOURCE after picking targets.
+#Two taps = +4 life (24); both targets tapped.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{4}{G}
+hand:jaddi lifestrider
+inplay:grizzly bears,hill giant
+[PLAYER2]
+[DO]
+jaddi lifestrider
+goto firstmain
+goto firstmain
+choice 0
+grizzly bears
+hill giant
+jaddi lifestrider
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:24
+inplay:jaddi lifestrider,grizzly bears,hill giant
+tappedinplay:2
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/krovikan_plague_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/krovikan_plague_i1085.txt
@@ -1,0 +1,29 @@
+#Krovikan Plague (#1085): aura teaches "{T}, put a -0/-1 counter: deal 1 damage to any
+#target". Enchant own bears, activate, hit the opponent's face: life 19, bears tapped.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{B}
+hand:krovikan plague
+inplay:grizzly bears
+library:millstone,juggernaut
+[PLAYER2]
+[DO]
+krovikan plague
+grizzly bears
+goto firstmain
+goto firstmain
+grizzly bears
+choice 0
+p2
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:krovikan plague,grizzly bears
+library:millstone,juggernaut
+tappedinplay:1
+[PLAYER2]
+life:19
+[END]

--- a/projects/mtg/bin/Res/test/generic/lazotep_chancellor_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/lazotep_chancellor_i1085.txt
@@ -1,0 +1,30 @@
+#Lazotep Chancellor (#1085): discard a card -> may pay {1} -> amass 2 (0/0 Zombie Army
+#with two +1/+1 counters; SBA survival at 2/2 proves the counters). Tormenting Voice
+#provides the discard.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{R}
+inplay:lazotep chancellor
+hand:tormenting voice,millstone
+library:juggernaut,gold myr
+[PLAYER2]
+[DO]
+tormenting voice
+millstone
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:lazotep chancellor,*
+graveyard:tormenting voice,millstone
+hand:gold myr,juggernaut
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/lich_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/lich_i1085.txt
@@ -1,0 +1,29 @@
+#Lich (#1085): life becomes 0 (can't lose the game from it, life can't change);
+#damage instead forces sacrificing that many nontoken permanents. Self-shock for 2:
+#sacrifice two myrs, life stays 0.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:lich,iron myr,gold myr,silver myr
+hand:shock
+[PLAYER2]
+[DO]
+iron myr
+shock
+p1
+goto firstmain
+goto firstmain
+choice 0
+gold myr
+silver myr
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:0
+inplay:lich,iron myr
+graveyard:shock,gold myr,silver myr
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/livewire_lash_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/livewire_lash_i1085.txt
@@ -1,0 +1,31 @@
+#Livewire Lash (#1085): equipped creature gets +2/+0 and deals 2 to any target when
+#targeted by a spell. Equip bears, shock the bears: the taught trigger hits the
+#opponent for 2 (life 18); the 4/2 bears dies to the 2-damage shock.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{R}
+inplay:livewire lash,grizzly bears
+hand:shock
+[PLAYER2]
+[DO]
+livewire lash
+grizzly bears
+goto firstmain
+goto firstmain
+shock
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+p2
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:livewire lash
+graveyard:shock,grizzly bears
+[PLAYER2]
+life:18
+[END]

--- a/projects/mtg/bin/Res/test/generic/living_death_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/living_death_i1085.txt
@@ -1,0 +1,28 @@
+#Living Death (#1085): each player exiles creatures from graveyard, sacrifices all
+#creatures, then returns the exiled ones. My bears swap with my graveyard giant;
+#opponent's myr swaps with their graveyard juggernaut.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{3}{B}{B}
+hand:living death
+inplay:grizzly bears
+graveyard:hill giant
+[PLAYER2]
+inplay:gold myr
+graveyard:juggernaut
+[DO]
+living death
+goto firstmain
+goto firstmain
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+inplay:hill giant
+graveyard:living death,grizzly bears
+[PLAYER2]
+inplay:juggernaut
+graveyard:gold myr
+[END]

--- a/projects/mtg/bin/Res/test/generic/loreseekers_stone_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/loreseekers_stone_i1085.txt
@@ -1,0 +1,21 @@
+#Loreseeker's Stone (#1085): {3+cards in hand}{T}: draw 3. Empty hand -> {3}{T}.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{3}
+inplay:loreseeker's stone
+library:millstone,juggernaut,gold myr,silver myr
+[PLAYER2]
+[DO]
+loreseeker's stone
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+hand:silver myr,gold myr,juggernaut
+inplay:loreseeker's stone
+library:millstone
+tappedinplay:1
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/mathas_fiend_seeker_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/mathas_fiend_seeker_i1085.txt
@@ -1,0 +1,38 @@
+#Mathas, Fiend Seeker (#1085; set id 571585): at my end step, bounty an opponent
+#creature; while bountied, its death makes each of its controller's opponents draw 1
+#and gain 2. Bounty the bears turn 1, shock them turn 3: P1 gains 2 (life 22) and
+#draws the rider card on top of the normal turn-3 draw.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:571585,iron myr
+hand:shock
+library:millstone,juggernaut
+[PLAYER2]
+inplay:grizzly bears
+[DO]
+goto end
+choice 0
+grizzly bears
+goto firstmain
+goto end
+goto firstmain
+iron myr
+shock
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:22
+hand:juggernaut,millstone
+inplay:571585,iron myr
+graveyard:shock
+tappedinplay:1
+[PLAYER2]
+graveyard:grizzly bears
+[END]

--- a/projects/mtg/bin/Res/test/generic/memorys_journey_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/memorys_journey_i1085.txt
@@ -1,0 +1,30 @@
+#Memory's Journey (#1085): target player shuffles up to three graveyard cards into their
+#library (the effect is granted to the targeted player). Target self, pick all three -
+#the upto:3 chooser completes at max. The spell itself is in the graveyard during the
+#granted ability and is a legal pick, so choose explicit cards.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{1}{U}
+hand:memory's journey
+graveyard:millstone,juggernaut,gold myr
+library:silver myr
+[PLAYER2]
+[DO]
+memory's journey
+p1
+goto firstmain
+goto firstmain
+choice 0
+millstone
+juggernaut
+gold myr
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+graveyard:memory's journey
+library:*,*,*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/misdirection_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/misdirection_i1085.txt
@@ -1,0 +1,36 @@
+#Misdirection (#1085): change the target of target spell with a single target.
+#P1 shocks P2; P2 interrupts with Misdirection and retargets the shock... at P1.
+#Same-phase INIT pool pays the {3}{U}{U}. The moved original deals nothing; the
+#recast copy takes a new target (P1) and connects for 2.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{R}
+hand:shock
+[PLAYER2]
+manapool:{3}{U}{U}
+hand:misdirection
+[DO]
+shock
+p2
+no
+yes
+misdirection
+choice 0
+shock
+goto firstmain
+goto firstmain
+p1
+goto firstmain
+goto firstmain
+endinterruption
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:18
+graveyard:shock
+[PLAYER2]
+graveyard:misdirection
+[END]

--- a/projects/mtg/bin/Res/test/generic/mobilized_district_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/mobilized_district_i1085.txt
@@ -1,0 +1,34 @@
+#Mobilized District (#1085): {4}: becomes a 3/3 Citizen with vigilance until end of turn
+#(cheaper per legend/planeswalker). No legends -> {4}. Animate with myr mana on turn 3,
+#attack: 3 damage, and vigilance means the district itself stays untapped.
+[INIT]
+firstmain
+[PLAYER1]
+inplay:mobilized district,gold myr,copper myr,silver myr,iron myr
+[PLAYER2]
+[DO]
+goto end
+goto firstmain
+goto end
+goto firstmain
+gold myr
+copper myr
+silver myr
+iron myr
+mobilized district
+choice 1
+goto firstmain
+goto firstmain
+goto attackers
+mobilized district
+choice 0
+next
+goto end
+[ASSERT]
+ENDOFTURN
+[PLAYER1]
+inplay:mobilized district,gold myr,copper myr,silver myr,iron myr
+tappedinplay:4
+[PLAYER2]
+life:17
+[END]

--- a/projects/mtg/bin/Res/test/generic/mwonvuli_beast_tracker_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/mwonvuli_beast_tracker_i1085.txt
@@ -1,0 +1,30 @@
+#Mwonvuli Beast Tracker (#1085): ETB - search library for a creature with deathtouch/
+#hexproof/reach/trample, reveal, shuffle, put it on top. Searching the trample krotiq
+#puts it on top: my next draw step draws it.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{1}{G}{G}
+hand:mwonvuli beast tracker
+library:millstone,gold myr,ambush krotiq
+[PLAYER2]
+[DO]
+mwonvuli beast tracker
+goto firstmain
+goto firstmain
+choice 0
+ambush krotiq
+goto firstmain
+goto firstmain
+goto end
+goto firstmain
+goto end
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+hand:ambush krotiq
+inplay:mwonvuli beast tracker
+library:*,*
+[PLAYER2]
+[END]

--- a/projects/mtg/bin/Res/test/generic/necrologia_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/necrologia_i1085.txt
@@ -1,0 +1,25 @@
+#Necrologia (#1085): pay X life, draw X - one merged menu entry per affordable X.
+#choice 2 = third entry = pay 3 life, draw 3 (life 17, hand 3).
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{3}{B}{B}
+hand:necrologia
+library:millstone,juggernaut,gold myr,silver myr
+[PLAYER2]
+[DO]
+necrologia
+goto firstmain
+goto firstmain
+choice 2
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+life:17
+hand:silver myr,gold myr,juggernaut
+graveyard:necrologia
+library:millstone
+[PLAYER2]
+[END]

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -8324,6 +8324,16 @@ AManaProducer::AManaProducer(GameObserver* observer, int id, MTGCardInstance * c
 int AManaProducer::isReactingToClick(MTGCardInstance * _card, ManaCost * mana)
 {
     int result = 0;
+    //This override bypasses ActivatedAbility::isReactingToClick entirely,
+    //so restriction{...} on mana abilities was silently ignored (e.g.
+    //Adarkar Unicorn's upkeep-only mana, #1085 list). Enforce it here the
+    //same way the base class does.
+    if (castRestriction.size())
+    {
+        AbilityFactory af(game);
+        if (!af.parseCastRestrictions(_card, _card->controller(), castRestriction))
+            return 0;
+    }
     if (!mana)
         mana = game->currentlyActing()->getManaPool();
     //please do not condense the following, I broke it apart for readability, it was far to difficult to tell what exactly happened before with it all in a single line.


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

First batch working through the #1085 card list, top to bottom.

## "AI uses Death Wind on its creatures"

Already handled: the card script's `ishuman` conditionals route AI casts to `opponentbattlefield` targets only, and the engine-side AI targeting fixes (#1167) cover the general case. Verified correct and pinned with `ai/death_wind_self_target_i1085.txt` (the AI kills the opponent's Raging Goblin and leaves its own board alone).

## "Adarkar Unicorn myupkeep only"

Two-part fix:
- **Data**: the card's mana is only for paying cumulative upkeep costs — which happens during your upkeep — but the script offered `{T}: Add {U}`/`{1}{U}` unrestricted, i.e. a free mana dork. Both abilities now carry `restriction{myupkeeponly}`.
- **Engine**: `AManaProducer::isReactingToClick` overrides `ActivatedAbility`'s version without the `castRestriction` check, so `restriction{...}` on *any* mana ability was silently ignored. Several existing card scripts already attach restrictions to mana abilities (`opponentturnonly`, `ishuman` compares, type-count conditions) and clearly expected enforcement; the same `parseCastRestrictions` gate the base class uses is now applied there too.

Tests: `generic/adarkar_unicorn_upkeep_i1085.txt` (mana flows during your upkeep) and `generic/adarkar_unicorn_mainphase_i1085.txt` (refused outside it).

## "Aegar, the Freezing Flame doesn't seem to work with instants and sorceries"

Not reproducible on master: excess spell damage (Shock into a 1/1) correctly triggers the draw. Pinned with `generic/aegar_spell_excess_i1085.txt`. (Note for test authors: the card name contains a comma, so tests must reference it by set id — the test suite's zone lists split on commas.)

Full suite on the fork: 741 tests + 4 AI tests, 0 failures.