### PR TITLE
Asymmetric two-target spells: prompt for the second target instead of fizzling

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,8 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/carom_i1085.txt
+generic/agony_warp_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/agony_warp_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/agony_warp_i1085.txt
@@ -1,0 +1,28 @@
+#Asymmetric two-target spells: a second effect line with its own
+#target(...) never prompted and silently fizzled (Carom, Agony Warp,
+#Rites of Reaping...). Agony Warp's -0/-3 leg must kill the goblin
+#while the -3/-0 leg leaves the bears alive.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:agony warp
+manapool:{U}{B}
+[PLAYER2]
+inplay:grizzly bears,raging goblin
+[DO]
+agony warp
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+raging goblin
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:agony warp
+[PLAYER2]
+inplay:grizzly bears
+graveyard:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/carom_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/carom_i1085.txt
@@ -1,0 +1,31 @@
+#From the #1085 meta-list: Carom (no symptom given).
+#Shield target creature for 1, deal 1 to another target creature
+#(script's redirect approximation), draw a card.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:grizzly bears
+hand:carom
+library:millstone
+manapool:{1}{W}
+[PLAYER2]
+inplay:raging goblin
+[DO]
+carom
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+raging goblin
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:grizzly bears
+graveyard:carom
+hand:millstone
+[PLAYER2]
+graveyard:raging goblin
+[END]

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2757,6 +2757,47 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
             return mainAbility;
         }
     }
+    //A plain spell-effect line carrying its own target(...) - Agony
+    //Warp's second line, Carom's redirect leg, Rites of Reaping... -
+    //historically lost its chooser: no leaf parser consumes `tc` on
+    //these paths, so the secondary effect silently fizzled when the
+    //spell resolved. Give such lines the mandatory-choice treatment
+    //(same wrapping the 'choice ' keyword gets) so the target is
+    //prompted for at resolution. Spell context only: the same card
+    //text parsed outside a resolving spell keeps its old meaning.
+    if (tc && spell)
+    {
+        //Only plain leaf effects opt in: the target() extraction above is
+        //not bracket-aware, so lines whose target(...) belongs to a NESTED
+        //ability (teach/transforms/newability grants, conditionals...)
+        //must fall through to their structural parsers untouched.
+        string trimmed = sWithoutTc;
+        size_t firstChar = trimmed.find_first_not_of(" ");
+        if (firstChar != string::npos)
+            trimmed = trimmed.substr(firstChar);
+        bool plainDamage = (trimmed.find("damage:") == 0);
+        bool plainPT = false;
+        {
+            size_t pos = 0;
+            if (pos < trimmed.size() && (trimmed[pos] == '+' || trimmed[pos] == '-')) pos++;
+            size_t digits = 0;
+            while (pos < trimmed.size() && isdigit(trimmed[pos])) { pos++; digits++; }
+            if (digits && pos < trimmed.size() && trimmed[pos] == '/')
+                plainPT = true;
+        }
+        if (plainDamage || plainPT)
+        {
+            MTGAbility * a1 = parseMagicLine(sWithoutTc, id, spell, card);
+            if (a1)
+            {
+                a1 = NEW GenericTargetAbility(observer, newName, castRestriction, id, card, tc, a1);
+                return NEW MayAbility(observer, id, a1, card, true, castRestriction);
+            }
+            SAFE_DELETE(tc);
+            return NULL;
+        }
+    }
+
     // Generic "Until end of turn" effect
     if (s.find("ueot ") == 0)
     {


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Found while triaging Carom from the #1085 list; affects a whole class of cards.

## The bug

Spells scripted with a card-level `target=` **plus** a second effect line carrying its own `target(...)` never ask for the second target — the spell goes on the stack right after the first target is clicked, and the secondary effect silently fizzles at resolution:

- **Agony Warp** (`target=creature` + `auto=0/-3 target(creature)`): the −0/−3 leg does nothing.
- **Carom** (`auto=damage:1 target(other creature)`): the redirect leg does nothing.
- **Rites of Reaping** and other cards using the same idiom.

Mechanism: no leaf parser (`damage:`, P/T modifiers, ...) consumes the per-line TargetChooser — only cost-prefixed (`{X}:`) and `may `/`choice ` lines wrap it in a `GenericTargetAbility`. For plain effect lines the chooser is parsed and then dropped.

## The fix

`parseMagicLine` now gives such lines the same mandatory-choice treatment the `choice ` keyword gets (`GenericTargetAbility` + `MayAbility(must)`), so the player is prompted for the target when the spell resolves. Two constraints keep the blast radius tight:

- **Spell context only** — the same card text parsed outside a resolving spell keeps its old meaning.
- **Only plain leaf effects opt in** (`damage:` and P/T modifiers). The top-of-parse `target()` extraction is not bracket-aware, so lines whose `target(...)` belongs to a *nested* ability (taught abilities, `transforms((newability[...]))` grants, conditionals) must fall through to their structural parsers untouched — a blanket wrap regressed five suite tests (deathtouch-taught, crosis catacombs ×2, flame fusillade, quilled sliver) before this narrowing.

## Tests

`generic/carom_i1085.txt` (the redirect leg kills the second creature; the shielded one survives, the draw happens) and `generic/agony_warp_i1085.txt` (the −0/−3 leg kills a Raging Goblin while the −3/−0 leg spares Grizzly Bears).

Full suite on the fork: 756 tests + 4 AI tests, 0 failures.