### PR TITLE
Countered flashback spells are exiled, not returned to the graveyard

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,7 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/dread_return_countered_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/dread_return_countered_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/dread_return_countered_i1085.txt
@@ -1,0 +1,35 @@
+#From the #1085 meta-list: "Dread Return flashback countered remains
+#in gy". A flashback cast that gets countered must EXILE the card
+#(CR 702.34a), not put it back in the graveyard.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:walking corpse,grizzly bears,hill giant
+graveyard:dread return,runeclaw bear
+offerinterruptonphase:firstmain
+[PLAYER2]
+hand:counterspell
+manapool:{U}{U}
+[DO]
+dread return
+choice 0
+walking corpse
+grizzly bears
+hill giant
+runeclaw bear
+no
+yes
+counterspell
+dread return
+endinterruption
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+exile:dread return
+graveyard:runeclaw bear,walking corpse,grizzly bears,hill giant
+[PLAYER2]
+graveyard:counterspell
+[END]

--- a/projects/mtg/src/ActionStack.cpp
+++ b/projects/mtg/src/ActionStack.cpp
@@ -1370,7 +1370,15 @@ void ActionStack::Fizzle(Interruptible * action, MTGCardInstance * fizzler, Fizz
         unsigned int position = 0;
         switch (fizzleMode) {
         case PUT_IN_GRAVEARD:
-            spell->source->controller()->game->putInGraveyard(spell->source);
+            //Flashback-cast spells are exiled wherever they would leave
+            //the stack - including when countered (CR 702.34a). The
+            //resolved path already does this; the countered path sent
+            //them back to the graveyard (Dread Return report in #1085).
+            if (spell->source->alternateCostPaid[ManaCost::MANA_PAID_WITH_FLASHBACK] > 0
+                || spell->source->basicAbilities[(int)Constants::TEMPFLASHBACK])
+                spell->source->controller()->game->putInExile(spell->source);
+            else
+                spell->source->controller()->game->putInGraveyard(spell->source);
             break;
         case PUT_IN_HAND:
             spell->source->controller()->game->putInHand(spell->source);


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

From the #1085 card list: *'Dread Return flashback countered remains in gy'* — reproduced and fixed.

## The bug

Flashback-cast spells are exiled wherever they would leave the stack (CR 702.34a). The **resolved** path handles this (the instant/sorcery end-of-resolution code routes `MANA_PAID_WITH_FLASHBACK` to exile), but the **countered** path — `ActionStack::Fizzle`'s `PUT_IN_GRAVEARD` case — sent the card back to the graveyard, ready to be flashed back again.

## The fix

The fizzle path now checks the same flashback payment markers (`alternateCostPaid[MANA_PAID_WITH_FLASHBACK]` / `TEMPFLASHBACK`) and routes to exile, mirroring the resolution code.

## Test

`generic/dread_return_countered_i1085.txt`: flashback-cast Dread Return (sacrificing three creatures), the opponent counters it, and the card must land in exile. Counterfactual verified — reverting the fix puts it back in the graveyard.

Full suite on the fork: 770 tests + 4 AI tests, 0 failures.