### PR TITLE
Spell lines with their own target() and a bare moveto() fizzled silently

### DIFF
--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -14,6 +14,8 @@ generic/changeling_i501.txt
 generic/cycling.txt
 generic/cycling2.txt
 generic/deathtouch.txt
+generic/carom_i1085.txt
+generic/agony_warp_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/_tests.txt
+++ b/projects/mtg/bin/Res/test/_tests.txt
@@ -16,6 +16,7 @@ generic/cycling2.txt
 generic/deathtouch.txt
 generic/carom_i1085.txt
 generic/agony_warp_i1085.txt
+generic/memory_leak_i1085.txt
 generic/devotion.txt
 generic/doesnotuntap.txt
 generic/doesnotuntap2.txt

--- a/projects/mtg/bin/Res/test/generic/agony_warp_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/agony_warp_i1085.txt
@@ -1,0 +1,28 @@
+#Asymmetric two-target spells: a second effect line with its own
+#target(...) never prompted and silently fizzled (Carom, Agony Warp,
+#Rites of Reaping...). Agony Warp's -0/-3 leg must kill the goblin
+#while the -3/-0 leg leaves the bears alive.
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+hand:agony warp
+manapool:{U}{B}
+[PLAYER2]
+inplay:grizzly bears,raging goblin
+[DO]
+agony warp
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+raging goblin
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+graveyard:agony warp
+[PLAYER2]
+inplay:grizzly bears
+graveyard:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/carom_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/carom_i1085.txt
@@ -1,0 +1,31 @@
+#From the #1085 meta-list: Carom (no symptom given).
+#Shield target creature for 1, deal 1 to another target creature
+#(script's redirect approximation), draw a card.
+# https://github.com/WagicProject/wagic/issues/1085
+[INIT]
+FIRSTMAIN
+[PLAYER1]
+inplay:grizzly bears
+hand:carom
+library:millstone
+manapool:{1}{W}
+[PLAYER2]
+inplay:raging goblin
+[DO]
+carom
+grizzly bears
+goto firstmain
+goto firstmain
+choice 0
+raging goblin
+goto secondmain
+goto secondmain
+[ASSERT]
+SECONDMAIN
+[PLAYER1]
+inplay:grizzly bears
+graveyard:carom
+hand:millstone
+[PLAYER2]
+graveyard:raging goblin
+[END]

--- a/projects/mtg/bin/Res/test/generic/memory_leak_i1085.txt
+++ b/projects/mtg/bin/Res/test/generic/memory_leak_i1085.txt
@@ -1,0 +1,28 @@
+#Memory Leak (#1085): opponent reveals hand; exile a nonland card from their hand or
+#graveyard. Exile the hill giant from hand.
+[INIT]
+firstmain
+[PLAYER1]
+manapool:{2}{B}
+hand:memory leak
+[PLAYER2]
+hand:hill giant,forest
+[DO]
+memory leak
+choice 0
+goto firstmain
+goto firstmain
+goto firstmain
+goto firstmain
+choice 0
+hill giant
+goto firstmain
+goto firstmain
+[ASSERT]
+FIRSTMAIN
+[PLAYER1]
+graveyard:memory leak
+[PLAYER2]
+hand:forest
+exile:hill giant
+[END]

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2785,7 +2785,17 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
             if (digits && pos < trimmed.size() && trimmed[pos] == '/')
                 plainPT = true;
         }
-        if (plainDamage || plainPT)
+        //A bare zone move with its own target() (Memory Leak's "exile a
+        //nonland card from that player's hand") fizzled the same way.
+        //Only the leaf form opts in: a chained/structural line keeps its
+        //old parse, since its target() may belong to the nested part.
+        bool plainMove = (trimmed.find("moveto(") == 0)
+            && trimmed.find("and!(") == string::npos
+            && trimmed.find("transforms(") == string::npos
+            && trimmed.find("newability") == string::npos
+            && trimmed.find("teach(") == string::npos
+            && trimmed.find("&&") == string::npos;
+        if (plainDamage || plainPT || plainMove)
         {
             MTGAbility * a1 = parseMagicLine(sWithoutTc, id, spell, card);
             if (a1)

--- a/projects/mtg/src/MTGAbility.cpp
+++ b/projects/mtg/src/MTGAbility.cpp
@@ -2757,6 +2757,47 @@ MTGAbility * AbilityFactory::parseMagicLine(string s, int id, Spell * spell, MTG
             return mainAbility;
         }
     }
+    //A plain spell-effect line carrying its own target(...) - Agony
+    //Warp's second line, Carom's redirect leg, Rites of Reaping... -
+    //historically lost its chooser: no leaf parser consumes `tc` on
+    //these paths, so the secondary effect silently fizzled when the
+    //spell resolved. Give such lines the mandatory-choice treatment
+    //(same wrapping the 'choice ' keyword gets) so the target is
+    //prompted for at resolution. Spell context only: the same card
+    //text parsed outside a resolving spell keeps its old meaning.
+    if (tc && spell)
+    {
+        //Only plain leaf effects opt in: the target() extraction above is
+        //not bracket-aware, so lines whose target(...) belongs to a NESTED
+        //ability (teach/transforms/newability grants, conditionals...)
+        //must fall through to their structural parsers untouched.
+        string trimmed = sWithoutTc;
+        size_t firstChar = trimmed.find_first_not_of(" ");
+        if (firstChar != string::npos)
+            trimmed = trimmed.substr(firstChar);
+        bool plainDamage = (trimmed.find("damage:") == 0);
+        bool plainPT = false;
+        {
+            size_t pos = 0;
+            if (pos < trimmed.size() && (trimmed[pos] == '+' || trimmed[pos] == '-')) pos++;
+            size_t digits = 0;
+            while (pos < trimmed.size() && isdigit(trimmed[pos])) { pos++; digits++; }
+            if (digits && pos < trimmed.size() && trimmed[pos] == '/')
+                plainPT = true;
+        }
+        if (plainDamage || plainPT)
+        {
+            MTGAbility * a1 = parseMagicLine(sWithoutTc, id, spell, card);
+            if (a1)
+            {
+                a1 = NEW GenericTargetAbility(observer, newName, castRestriction, id, card, tc, a1);
+                return NEW MayAbility(observer, id, a1, card, true, castRestriction);
+            }
+            SAFE_DELETE(tc);
+            return NULL;
+        }
+    }
+
     // Generic "Until end of turn" effect
     if (s.find("ueot ") == 0)
     {


### PR DESCRIPTION
Generated through agentic engineering with Claude Fable 5.

Found via **Memory Leak** from the #1085 list: its 'exile a nonland card from that player's hand or graveyard' line resolved as a complete no-op — the spell went to the graveyard and nothing was exiled, with no prompt.

This is the same lost-chooser class as #1173 (Carom / Agony Warp): the top-of-parse `target()` extraction strips the line's chooser, but the `moveto` leaf parser never consumes it, so the effect silently fizzles at resolution. The spell-context wrap from #1173 now also accepts lines whose effect (after name/target extraction) begins with `moveto(` — guarded to skip chained/structural shapes (`and!(`, `transforms(`, `newability`, `teach(`, `&&`) whose `target()` may belong to the nested part, which was the regression class the #1173 whitelist was narrowed against.

**Stacked on #1173** (it extends that PR's whitelist block); merging #1173 first makes this a clean two-commit diff.

Regression test: Memory Leak exiles the opponent's Hill Giant from hand (fails before the fix, passes after). Full suite on the fork: 794 + 4 AI, 0 failures (runner from #1155, build from #1153).